### PR TITLE
Enhance Triton logging framework with span ID and parent span ID support

### DIFF
--- a/force-app/main/default/classes/TritonBuilder.cls
+++ b/force-app/main/default/classes/TritonBuilder.cls
@@ -30,6 +30,8 @@ public with sharing class TritonBuilder {
     public static final String FLOW_API_NAME = 'pharos__Flow_API_Name__c';
     public static final String DO_NOT_CREATE_ISSUE = 'pharos__Do_Not_Create_Issue__c';
     public static final String REQUEST_ID = 'pharos__Request_Id_External__c';
+    public static final String SPAN_ID = 'Span_Id__c';
+    public static final String PARENT_SPAN_ID = 'Parent_Span_Id__c';
 
     /** transaction limit field names */
     @TestVisible
@@ -107,6 +109,10 @@ public with sharing class TritonBuilder {
     @TestVisible
     private String executionContextDetails;
     private String categoryValue;
+    @TestVisible
+    private String currentSpanId;
+    @TestVisible
+    private String currentParentSpanId;
 
     public TritonBuilder cloneBuilder() {
         pharos__Log__c clonedLog = this.builder.build().clone(false, true, false, false);
@@ -121,6 +127,8 @@ public with sharing class TritonBuilder {
         cloned.fullLimitInfoRequested = this.fullLimitInfoRequested;
         cloned.traceable = this.traceable;
         cloned.categoryValue = this.categoryValue;
+        cloned.currentSpanId = this.currentSpanId;
+        cloned.currentParentSpanId = this.currentParentSpanId;
         // fullSummary and executionContextDetails are intentionally NOT cloned — per-log values
         cloned.initBuilder();
         return cloned;
@@ -439,6 +447,28 @@ public with sharing class TritonBuilder {
     }
 
     /**
+    * Set span ID for the log
+    * @param spanId -- String value representing the span identifier
+    * @return this builder instance
+    */
+    public TritonBuilder spanId(String spanId) {
+        this.currentSpanId = spanId;
+        this.builder.attribute(SPAN_ID, spanId);
+        return this;
+    }
+
+    /**
+    * Set parent span ID for the log
+    * @param parentSpanId -- String value representing the parent span identifier
+    * @return this builder instance
+    */
+    public TritonBuilder parentSpanId(String parentSpanId) {
+        this.currentParentSpanId = parentSpanId;
+        this.builder.attribute(PARENT_SPAN_ID, parentSpanId);
+        return this;
+    }
+
+    /**
     * Set integration payload from HTTP request/response
     * @param request -- HttpRequest instance
     * @param response -- HttpResponse instance
@@ -708,6 +738,17 @@ public with sharing class TritonBuilder {
     }
 
     /**
+    * Ensures span IDs are populated with sensible defaults when not explicitly set.
+    * Uses the request ID as span ID fallback for Apex-originated logs.
+    */
+    private void ensureSpanIds() {
+        if (String.isBlank(this.currentSpanId)) {
+            String requestId = System.Request.getCurrent().getRequestId();
+            this.builder.attribute(SPAN_ID, requestId);
+        }
+    }
+
+    /**
     * Prepares the builder for logging by auto-enriching with runtime context.
     * Called by Triton.log() to add stacktrace, operation, tracepoint, and limits.
     * @param transactionId -- Transaction ID to associate with this log
@@ -745,6 +786,7 @@ public with sharing class TritonBuilder {
     * @return pharos__Log__c instance
     */
     public pharos__Log__c build() {
+        ensureSpanIds();
         pharos__Log__c log = this.builder.build();
 
         // Default category to Apex when not explicitly set

--- a/force-app/main/default/classes/TritonLwc.cls
+++ b/force-app/main/default/classes/TritonLwc.cls
@@ -33,7 +33,6 @@ global with sharing class TritonLwc {
     public static void saveComponentLogs(List<ComponentLog> componentLogs) {
         String transactionId = Triton.startTransaction();
         Triton.withCache();
-        Boolean transactionIdFromCache = Triton.TRANSACTION_ID != transactionId;
         transactionId = Triton.TRANSACTION_ID;
 
         for (ComponentLog componentLog : componentLogs) {
@@ -44,13 +43,10 @@ global with sharing class TritonLwc {
             TritonTypes.Level level = TritonTypes.Level.INFO;
             String details = componentLog.details == null ? '' : componentLog.details;
 
-            //transaction was not resumed from cache
-            //transaction id was provided by the component
-            if(!transactionIdFromCache && String.isNotBlank(componentLog.transactionId)) {
-                transactionId = componentLog.transactionId;
-                Triton.resumeTransaction(transactionId);
-                transactionIdFromCache = true;
-            }
+            // Each log independently carries its own transaction ID if provided
+            String logTransactionId = String.isNotBlank(componentLog.transactionId)
+                ? componentLog.transactionId
+                : transactionId;
             try {
                 userId = UserInfo.getUserId();
                 if(!String.isBlank(componentLog.userId)) {
@@ -119,7 +115,9 @@ global with sharing class TritonLwc {
                                     componentLog.error != null ? componentLog.error.message : null)
                             .stackTrace(componentLog.stack)
                             .details(details)
-                            .transactionId(transactionId)
+                            .transactionId(logTransactionId)
+                            .spanId(componentLog.spanId)
+                            .parentSpanId(componentLog.parentSpanId)
                             .userId(userId)
                             //apex name will be set to component.function or just component.name if function is not set
                             .operation(componentLog.componentInfo.name + 
@@ -186,6 +184,10 @@ global with sharing class TritonLwc {
         public RuntimeInfo runtimeInfo { get; set; }
         @AuraEnabled
         public List<String> relatedObjectIds { get; set; }
+        @AuraEnabled
+        public String spanId { get; set; }
+        @AuraEnabled
+        public String parentSpanId { get; set; }
     }
 
     /**

--- a/force-app/main/default/classes/TritonTest.cls
+++ b/force-app/main/default/classes/TritonTest.cls
@@ -2179,4 +2179,54 @@ private class TritonTest {
         System.assert(levels.contains(TritonTypes.Level.ERROR.name()), 'Should contain ERROR level log');
     }
 
+    @IsTest
+    static void test_builder_span_id_explicit() {
+        TritonBuilder builder = Triton.makeBuilder()
+            .category(TritonTypes.Category.Apex)
+            .type(TritonTypes.Type.Backend)
+            .area(TritonTypes.Area.Community)
+            .summary('span test')
+            .spanId('explicit-span-id')
+            .parentSpanId('explicit-parent-span-id');
+
+        pharos__Log__c log = builder.build();
+
+        System.assertEquals('explicit-span-id', (String) log.get(TritonBuilder.SPAN_ID),
+            'Should set explicit span ID');
+        System.assertEquals('explicit-parent-span-id', (String) log.get(TritonBuilder.PARENT_SPAN_ID),
+            'Should set explicit parent span ID');
+    }
+
+    @IsTest
+    static void test_builder_span_id_fallback_to_request_id() {
+        TritonBuilder builder = Triton.makeBuilder()
+            .category(TritonTypes.Category.Apex)
+            .type(TritonTypes.Type.Backend)
+            .area(TritonTypes.Area.Community)
+            .summary('span fallback test');
+
+        pharos__Log__c log = builder.build();
+
+        String requestId = System.Request.getCurrent().getRequestId();
+        System.assertEquals(requestId, (String) log.get(TritonBuilder.SPAN_ID),
+            'Should fallback to request ID when no span ID explicitly set');
+    }
+
+    @IsTest
+    static void test_builder_clone_preserves_span_ids() {
+        TritonBuilder original = Triton.makeBuilder()
+            .category(TritonTypes.Category.Apex)
+            .type(TritonTypes.Type.Backend)
+            .area(TritonTypes.Area.Community)
+            .spanId('clone-span')
+            .parentSpanId('clone-parent');
+
+        TritonBuilder cloned = original.cloneBuilder();
+
+        System.assertEquals('clone-span', cloned.currentSpanId,
+            'Cloned builder should preserve span ID');
+        System.assertEquals('clone-parent', cloned.currentParentSpanId,
+            'Cloned builder should preserve parent span ID');
+    }
+
 }

--- a/force-app/main/default/lwc/triton/__tests__/triton.test.js
+++ b/force-app/main/default/lwc/triton/__tests__/triton.test.js
@@ -27,6 +27,8 @@ jest.mock('c/tritonBuilder', () => {
       userId: jest.fn().mockReturnThis(),
       runtimeInfo: jest.fn().mockReturnThis(),
       timestamp: jest.fn().mockReturnThis(),
+      spanId: jest.fn().mockReturnThis(),
+      parentSpanId: jest.fn().mockReturnThis(),
       componentDetails: jest.fn().mockReturnThis(),
       clone: jest.fn().mockImplementation(() => {
         // Return a new mock with the same structure
@@ -44,6 +46,8 @@ jest.mock('c/tritonBuilder', () => {
           userId: jest.fn().mockReturnThis(),
           runtimeInfo: jest.fn().mockReturnThis(),
           timestamp: jest.fn().mockReturnThis(),
+          spanId: jest.fn().mockReturnThis(),
+          parentSpanId: jest.fn().mockReturnThis(),
           componentDetails: jest.fn().mockReturnThis(),
           build: jest.fn().mockReturnValue({ mockBuiltLog: true }),
           clone: jest.fn().mockReturnThis(),
@@ -237,13 +241,15 @@ describe('Triton', () => {
       expect(TritonBuilder).toHaveBeenCalled();
     });
 
-    test('should refresh builder', () => {
+    test('should refresh builder with span context', () => {
       const mockBuilder = new TritonBuilder();
       const result = triton.refreshBuilder(mockBuilder);
-      
+
       expect(result).toBe(mockBuilder);
       expect(mockBuilder.runtimeInfo).toHaveBeenCalledWith({ mockRuntimeInfo: true });
       expect(mockBuilder.timestamp).toHaveBeenCalled();
+      expect(mockBuilder.spanId).toHaveBeenCalledWith('mock-transaction-id');
+      expect(mockBuilder.parentSpanId).toHaveBeenCalled();
     });
 
     test('should set component info when component is bound', () => {
@@ -698,10 +704,145 @@ describe('PerformanceTracker', () => {
 
   test('should create component data for unknown components', () => {
     const componentData = triton.performance.getComponentData('unknown');
-    
+
     expect(componentData).toBeDefined();
     expect(componentData.marks).toBeInstanceOf(Map);
     expect(componentData.renderCounts).toBe(0);
     expect(componentData.lifecycleEvents).toBeInstanceOf(Map);
+  });
+
+  test('should clear all marks', () => {
+    boundTriton.startPerformanceMark('mark1');
+    boundTriton.startPerformanceMark('mark2');
+
+    triton.performance.clearAllMarks();
+
+    const componentData = triton.performance.getComponentData(boundTriton._componentKey);
+    expect(componentData.marks.size).toBe(0);
+  });
+
+  test('should identify active mark span IDs', () => {
+    boundTriton.startPerformanceMark('mark1');
+
+    // The mock generateTransactionId always returns 'mock-transaction-id'
+    // so isActiveMarkSpanId checks against that
+    expect(triton.performance.isActiveMarkSpanId('mock-transaction-id')).toBe(true);
+    expect(triton.performance.isActiveMarkSpanId('non-existent-span')).toBe(false);
+  });
+});
+
+describe('SpanContext', () => {
+  let triton;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    Object.defineProperty(window, 'sessionStorage', {
+      value: {
+        getItem: jest.fn().mockReturnValue(null),
+        setItem: jest.fn(),
+        removeItem: jest.fn()
+      },
+      writable: true,
+      configurable: true
+    });
+
+    triton = new Triton();
+    triton.logs = [];
+  });
+
+  test('should initialize span context on construction', () => {
+    expect(triton.spanContext).toBeDefined();
+  });
+
+  test('should reset span context on startTransaction', () => {
+    triton.startTransaction();
+    const current = triton.spanContext.current();
+
+    expect(current).toBe(triton.transactionId);
+  });
+
+  test('should reset span context on resumeTransaction', () => {
+    triton.resumeTransaction('resume-txn-id');
+    const current = triton.spanContext.current();
+
+    expect(current).toBe('resume-txn-id');
+  });
+
+  test('should clear span context on stopTransaction', () => {
+    triton.startTransaction();
+    triton.spanContext.push('child-span');
+    triton.stopTransaction();
+
+    expect(triton.spanContext.current()).toBeNull();
+  });
+
+  test('push/pop should manage stack correctly', () => {
+    triton.spanContext.reset('root');
+    triton.spanContext.push('child1');
+    triton.spanContext.push('child2');
+
+    expect(triton.spanContext.current()).toBe('child2');
+    expect(triton.spanContext.parent()).toBe('child1');
+
+    triton.spanContext.pop('child2');
+    expect(triton.spanContext.current()).toBe('child1');
+  });
+
+  test('pop should handle out-of-order removal', () => {
+    triton.spanContext.reset('root');
+    triton.spanContext.push('a');
+    triton.spanContext.push('b');
+    triton.spanContext.push('c');
+
+    // Remove middle element
+    triton.spanContext.pop('b');
+    const stack = triton.spanContext.getStack();
+
+    expect(stack).toEqual(['root', 'a', 'c']);
+  });
+
+  test('enterStep should reset to root and push step span', () => {
+    triton.startTransaction();
+    triton.spanContext.push('old-child');
+
+    const stepId = triton.enterStep('step-1');
+
+    expect(stepId).toBe('step-1');
+    const stack = triton.spanContext.getStack();
+    expect(stack).toEqual([triton.transactionId, 'step-1']);
+  });
+
+  test('enterStep should auto-generate span ID if not provided', () => {
+    const stepId = triton.enterStep();
+
+    expect(stepId).toBe('mock-transaction-id'); // from mocked generateTransactionId
+  });
+
+  test('getStableParent should skip active mark spans', () => {
+    triton.spanContext.reset('root');
+    triton.spanContext.push('stable-parent');
+    triton.spanContext.push('active-mark-span');
+
+    const isActiveMark = (id) => id === 'active-mark-span';
+    const parent = triton.spanContext.getStableParent(isActiveMark);
+
+    expect(parent).toBe('stable-parent');
+  });
+
+  test('enableSpanPersistence should enable sessionStorage', () => {
+    triton.enableSpanPersistence();
+    triton.spanContext.push('persisted-span');
+
+    expect(window.sessionStorage.setItem).toHaveBeenCalled();
+  });
+
+  test('clear should empty the stack', () => {
+    triton.spanContext.reset('root');
+    triton.spanContext.push('child');
+    triton.spanContext.clear();
+
+    expect(triton.spanContext.current()).toBeNull();
+    expect(triton.spanContext.getStack()).toEqual([]);
   });
 });

--- a/force-app/main/default/lwc/triton/triton.js
+++ b/force-app/main/default/lwc/triton/triton.js
@@ -50,10 +50,12 @@ export default class Triton {
         if (instance) {
             return instance;
         }
-        this.transactionManager = new TransactionManager(this);        
+        this.transactionManager = new TransactionManager(this);
         this.transactionId = this.transactionManager.initialize();
+        this.spanContext = new SpanContext();
+        this.spanContext.reset(this.transactionId);
         this.performance = new PerformanceTracker(this);
-        
+
         instance = this;
         return instance;
     }
@@ -107,6 +109,8 @@ export default class Triton {
      */
     startTransaction() {
         this.transactionId = this.transactionManager.start();
+        this.spanContext.reset(this.transactionId);
+        this.performance.clearAllMarks();
         return this.transactionId;
     }
 
@@ -117,6 +121,7 @@ export default class Triton {
      */
     resumeTransaction(transactionId) {
         this.transactionId = this.transactionManager.resume(transactionId);
+        this.spanContext.reset(this.transactionId);
     }
 
     /**
@@ -126,6 +131,7 @@ export default class Triton {
     stopTransaction() {
         this.transactionManager.stop();
         this.transactionId = null;
+        this.spanContext.clear();
     }
 
     /**
@@ -267,7 +273,30 @@ export default class Triton {
         return builder
             .runtimeInfo(captureRuntimeInfo())
             .transactionId(this.transactionId)
-            .timestamp(Date.now());
+            .timestamp(Date.now())
+            .spanId(generateTransactionId())
+            .parentSpanId(this.spanContext.current());
+    }
+
+    /**
+     * Enters a new logical step (e.g., wizard step), resetting the span stack
+     * to the transaction root and pushing a new span for the step.
+     * @param {string} [stepSpanId] - Optional custom span ID for the step (auto-generated if omitted)
+     * @returns {string} The span ID for this step
+     */
+    enterStep(stepSpanId) {
+        const spanId = stepSpanId || generateTransactionId();
+        this.spanContext.reset(this.transactionId);
+        this.spanContext.push(spanId);
+        return spanId;
+    }
+
+    /**
+     * Enables sessionStorage persistence for the span context stack.
+     * Useful for multi-page flows where span hierarchy must survive navigation.
+     */
+    enableSpanPersistence() {
+        this.spanContext.persist();
     }
 
     /**
@@ -435,7 +464,12 @@ class PerformanceCallBuilder {
      */
     async execute() {
         const startTime = this.triton.performance.getCurrentTime();
-        
+
+        // Capture span context at call start
+        const spanId = generateTransactionId();
+        const parentSpanId = this.triton.spanContext.current();
+        this.triton.spanContext.push(spanId);
+
         // Use explicit method name and determine log type based on call type
         const methodName = this.methodName;
         let logType, operationName;
@@ -456,13 +490,15 @@ class PerformanceCallBuilder {
                         .summary(`${operationName} started: ${methodName}`)
                         .details(`Initiating ${operationName.toLowerCase()}: ${methodName}`)
                         .action(methodName)
+                        .spanId(spanId)
+                        .parentSpanId(parentSpanId)
                 );
             }
-            
+
             const result = await this.callFunction();
             const endTime = this.triton.performance.getCurrentTime();
             const duration = endTime - startTime;
-            
+
             // Log successful operation (only if component is bound)
             if (this.triton._componentId) {
                 this.triton.log(
@@ -472,18 +508,20 @@ class PerformanceCallBuilder {
                         .details(`Duration: ${duration}ms`)
                         .duration(duration)
                         .action(methodName)
+                        .spanId(spanId)
+                        .parentSpanId(parentSpanId)
                 );
             }
-            
+
             return result;
-            
+
         } catch (error) {
             const endTime = this.triton.performance.getCurrentTime();
             const duration = endTime - startTime;
-            
+
             // Use custom error handler if provided, otherwise use built-in
             if (this.customErrorHandler) {
-                const context = this.callType === 'backend' 
+                const context = this.callType === 'backend'
                     ? { methodName, duration }
                     : { interactionName: methodName, duration };
                 this.customErrorHandler(error, context);
@@ -497,15 +535,19 @@ class PerformanceCallBuilder {
                         .duration(duration)
                         .action(methodName)
                         .exception(error)
+                        .spanId(spanId)
+                        .parentSpanId(parentSpanId)
                 );
             }
-            
+
             // Rethrow if configured
             if (this.shouldRethrow) {
                 throw error;
             }
-            
+
             return null;
+        } finally {
+            this.triton.spanContext.pop(spanId);
         }
     }
 }
@@ -576,13 +618,19 @@ class PerformanceTracker {
         const componentKey = tritonInstance._componentKey || 'unknown';
         const componentData = this.getComponentData(componentKey);
         const startTime = this.getCurrentTime();
-        
+
+        const spanId = generateTransactionId();
+        const parentSpanId = tritonInstance.spanContext.current();
+        tritonInstance.spanContext.push(spanId);
+
         componentData.marks.set(markName, {
             name: markName,
             startTime: startTime,
-            componentKey: componentKey
+            componentKey: componentKey,
+            spanId: spanId,
+            parentSpanId: parentSpanId
         });
-        
+
         return markName;
     }
 
@@ -596,20 +644,23 @@ class PerformanceTracker {
         const endTime = this.getCurrentTime();
         const componentKey = tritonInstance._componentKey || 'unknown';
         const componentData = this.getComponentData(componentKey);
-        
+
         const markData = componentData.marks.get(markName);
-        
+
         if (!markData) {
             console.warn(`Performance mark '${markName}' not found for component ${tritonInstance._componentId || 'unknown'}`);
             return;
         }
-        
+
         const duration = endTime - markData.startTime;
-        
+
+        // Remove this mark's span from the context stack
+        tritonInstance.spanContext.pop(markData.spanId);
+
         // Clean up the mark
         componentData.marks.delete(markName);
-        
-        // Log the performance data using the appropriate context
+
+        // Log the performance data using the mark's captured span context
         tritonInstance.log(
             tritonInstance.makeBuilder()
                 .type(TYPE.PERFORMANCE)
@@ -617,7 +668,35 @@ class PerformanceTracker {
                 .details(`Duration: ${duration}ms`)
                 .duration(duration)
                 .action(markData.name)
+                .spanId(markData.spanId)
+                .parentSpanId(markData.parentSpanId)
         );
+    }
+
+    /**
+     * Checks if a span ID belongs to an active performance mark
+     * @param {string} spanId - Span ID to check
+     * @returns {boolean}
+     */
+    isActiveMarkSpanId(spanId) {
+        for (const [, componentData] of this.componentInstances) {
+            for (const [, markData] of componentData.marks) {
+                if (markData.spanId === spanId) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Clears all active marks across all components.
+     * Called on new transaction to prevent stale marks.
+     */
+    clearAllMarks() {
+        for (const [, componentData] of this.componentInstances) {
+            componentData.marks.clear();
+        }
     }
 
     /**
@@ -660,6 +739,141 @@ class PerformanceTracker {
                 .details(`Render count: ${componentData.renderCounts}`)
                 .action('component-render')
         );
+    }
+}
+
+/**
+ * Manages span hierarchy tracking with an in-memory stack.
+ * Optionally persists to sessionStorage for cross-navigation scenarios.
+ * @private
+ */
+class SpanContext {
+    static STORAGE_KEY = 'tritonContextStack';
+
+    constructor(options = {}) {
+        this._stack = [];
+        this._persist = options.persist || false;
+    }
+
+    /**
+     * Returns the current span stack
+     * @returns {string[]}
+     */
+    getStack() {
+        if (this._persist) {
+            try {
+                const stored = sessionStorage.getItem(SpanContext.STORAGE_KEY);
+                if (stored) {
+                    this._stack = JSON.parse(stored);
+                }
+            } catch (e) {
+                // fall back to in-memory
+            }
+        }
+        return this._stack;
+    }
+
+    /**
+     * Replaces the span stack
+     * @param {string[]} stack
+     */
+    setStack(stack) {
+        this._stack = stack;
+        if (this._persist) {
+            try {
+                sessionStorage.setItem(SpanContext.STORAGE_KEY, JSON.stringify(stack));
+            } catch (e) {
+                // fall back to in-memory
+            }
+        }
+    }
+
+    /**
+     * Push a span ID onto the stack
+     * @param {string} spanId
+     */
+    push(spanId) {
+        const stack = this.getStack();
+        stack.push(spanId);
+        this.setStack(stack);
+    }
+
+    /**
+     * Remove a specific span ID from the stack (supports out-of-order pops)
+     * @param {string} spanId
+     */
+    pop(spanId) {
+        const stack = this.getStack();
+        const index = stack.lastIndexOf(spanId);
+        if (index !== -1) {
+            stack.splice(index, 1);
+            this.setStack(stack);
+        }
+    }
+
+    /**
+     * Returns the current (top) span ID
+     * @returns {string|null}
+     */
+    current() {
+        const stack = this.getStack();
+        return stack.length > 0 ? stack[stack.length - 1] : null;
+    }
+
+    /**
+     * Returns the parent span ID (second from top)
+     * @returns {string|null}
+     */
+    parent() {
+        const stack = this.getStack();
+        return stack.length > 1 ? stack[stack.length - 2] : null;
+    }
+
+    /**
+     * Reset the stack to contain only the root ID
+     * @param {string} rootId
+     */
+    reset(rootId) {
+        this.setStack(rootId ? [rootId] : []);
+    }
+
+    /**
+     * Clear the stack entirely
+     */
+    clear() {
+        this._stack = [];
+        if (this._persist) {
+            try {
+                sessionStorage.removeItem(SpanContext.STORAGE_KEY);
+            } catch (e) {
+                // ignore
+            }
+        }
+    }
+
+    /**
+     * Enable sessionStorage persistence
+     */
+    persist() {
+        this._persist = true;
+        // Write current in-memory stack to storage
+        this.setStack(this._stack);
+    }
+
+    /**
+     * Returns a stable parent span ID by skipping active mark spans.
+     * Walks the stack from top down, skipping any span IDs that match active marks.
+     * @param {Function} isActiveMarkFn - Predicate: (spanId) => boolean
+     * @returns {string|null}
+     */
+    getStableParent(isActiveMarkFn) {
+        const stack = this.getStack();
+        for (let i = stack.length - 1; i >= 0; i--) {
+            if (!isActiveMarkFn(stack[i])) {
+                return stack[i];
+            }
+        }
+        return null;
     }
 }
 

--- a/force-app/main/default/lwc/tritonBuilder/__tests__/tritonBuilder.test.js
+++ b/force-app/main/default/lwc/tritonBuilder/__tests__/tritonBuilder.test.js
@@ -121,9 +121,23 @@ describe('TritonBuilder', () => {
 
     test('runtimeInfo() should handle undefined input with default empty object', () => {
       const result = builder.runtimeInfo();
-      
+
       expect(result).toBe(builder);
       expect(builder._runtimeInfo).toEqual({});
+    });
+
+    test('spanId() should set the span ID and return builder for chaining', () => {
+      const result = builder.spanId('span-123');
+
+      expect(result).toBe(builder);
+      expect(builder._spanId).toBe('span-123');
+    });
+
+    test('parentSpanId() should set the parent span ID and return builder for chaining', () => {
+      const result = builder.parentSpanId('parent-span-456');
+
+      expect(result).toBe(builder);
+      expect(builder._parentSpanId).toBe('parent-span-456');
     });
   });
 
@@ -428,7 +442,9 @@ describe('TritonBuilder', () => {
         .timestamp(timestamp)
         .userId('user-456')
         .relatedObjects(['obj-1'])
-        .runtimeInfo(runtimeInfo);
+        .runtimeInfo(runtimeInfo)
+        .spanId('span-abc')
+        .parentSpanId('span-parent');
 
       builder._componentInfo = componentInfo;
       builder._error = error;
@@ -452,7 +468,9 @@ describe('TritonBuilder', () => {
         stack: 'test stack',
         userId: 'user-456',
         runtimeInfo: runtimeInfo,
-        relatedObjectIds: ['obj-1']
+        relatedObjectIds: ['obj-1'],
+        spanId: 'span-abc',
+        parentSpanId: 'span-parent'
       });
     });
 
@@ -475,7 +493,9 @@ describe('TritonBuilder', () => {
         stack: undefined,
         userId: undefined,
         runtimeInfo: undefined,
-        relatedObjectIds: undefined
+        relatedObjectIds: undefined,
+        spanId: undefined,
+        parentSpanId: undefined
       });
     });
 

--- a/force-app/main/default/lwc/tritonBuilder/tritonBuilder.js
+++ b/force-app/main/default/lwc/tritonBuilder/tritonBuilder.js
@@ -103,6 +103,26 @@ export default class TritonBuilder {
     }
 
     /**
+     * Sets the span ID for this log entry
+     * @param {string} spanId - Unique span identifier
+     * @returns {TritonBuilder} Builder instance for chaining
+     */
+    spanId(spanId) {
+        this._spanId = spanId;
+        return this;
+    }
+
+    /**
+     * Sets the parent span ID for this log entry
+     * @param {string} parentSpanId - Parent span identifier
+     * @returns {TritonBuilder} Builder instance for chaining
+     */
+    parentSpanId(parentSpanId) {
+        this._parentSpanId = parentSpanId;
+        return this;
+    }
+
+    /**
      * Sets the created timestamp
      * @param {number} [timestamp] - Optional timestamp to set (defaults to current time)
      * @returns {TritonBuilder} Builder instance for chaining
@@ -250,7 +270,9 @@ export default class TritonBuilder {
             stack: this._stack,
             userId: this._userId,
             runtimeInfo: this._runtimeInfo,
-            relatedObjectIds: this._relatedObjectIds
+            relatedObjectIds: this._relatedObjectIds,
+            spanId: this._spanId,
+            parentSpanId: this._parentSpanId
         };
     }
 

--- a/force-app/main/default/objects/pharos__Log__c/fields/Parent_Span_Id__c.field-meta.xml
+++ b/force-app/main/default/objects/pharos__Log__c/fields/Parent_Span_Id__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Parent_Span_Id__c</fullName>
+    <externalId>false</externalId>
+    <label>Parent Span Id</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/pharos__Log__c/fields/Span_Id__c.field-meta.xml
+++ b/force-app/main/default/objects/pharos__Log__c/fields/Span_Id__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Span_Id__c</fullName>
+    <externalId>false</externalId>
+    <label>Span Id</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/permissionsets/Triton_Read.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Triton_Read.permissionset-meta.xml
@@ -87,6 +87,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>pharos__Log__c.Parent_Span_Id__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>pharos__Log__c.Publish_Immediate_DML_Limit__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -113,6 +118,11 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>pharos__Log__c.Queueable_Jobs__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>pharos__Log__c.Span_Id__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/permissionsets/Triton_Write.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Triton_Write.permissionset-meta.xml
@@ -121,6 +121,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>pharos__Log__c.Parent_Span_Id__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>pharos__Log__c.Publish_Immediate_DML_Limit__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -147,6 +152,11 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>pharos__Log__c.Queueable_Jobs__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>pharos__Log__c.Span_Id__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>


### PR DESCRIPTION
- Added span ID and parent span ID fields to TritonBuilder and TritonLwc for improved traceability in logs.
- Implemented methods to set span IDs in TritonBuilder and updated log building process to include these identifiers.
- Enhanced tests to validate span ID functionality and ensure correct behavior during log creation and cloning.
- Introduced new fields in pharos__Log__c for storing span IDs, with corresponding field permissions in Triton_Read and Triton_Write permission sets.