### PR TITLE
Fix cache tests to use Session Cache

### DIFF
--- a/force-app/main/default/classes/TritonTest.cls
+++ b/force-app/main/default/classes/TritonTest.cls
@@ -1309,21 +1309,32 @@ private class TritonTest {
     private static void test_cache_functionality() {
         Test.startTest();
         
-        // Test withCache when cache is available
-        Cache.Org.put('test', 'test'); // This will make CACHE_AVAILABLE true
+        Boolean sessionCacheAvailable;
+        try {
+            Cache.Session.getKeys();
+            sessionCacheAvailable = true;
+        } catch (Exception e) {
+            sessionCacheAvailable = false;
+        }
+
+        // Production transaction caching uses Cache.Session. Cache.Org requires
+        // a default partition, which is not present in every validation org.
+        Triton.CACHE_AVAILABLE = sessionCacheAvailable;
         Triton instance = Triton.instance.withCache();
-        System.assert(instance.withCache, 'Cache should be enabled');
+        System.assertEquals(sessionCacheAvailable, instance.withCache, 'Cache usage should match Session Cache availability');
         
         // Start a transaction and verify it's cached
         String transactionId = instance.startTransaction();
         System.assertNotEquals(null, transactionId, 'Transaction ID should be generated');
-        System.assertEquals(transactionId, TritonHelper.getCachedTransactionId(), 'Transaction ID should be cached');
-        
+        String expectedCachedTransactionId = sessionCacheAvailable ? transactionId : null;
+        System.assertEquals(expectedCachedTransactionId, TritonHelper.getCachedTransactionId(), 'Transaction cache should match Session Cache availability');
+
         // Resume transaction and verify cache is updated
         String newTransactionId = 'test-transaction-id';
         instance.resumeTransaction(newTransactionId);
-        System.assertEquals(newTransactionId, TritonHelper.getCachedTransactionId(), 'New transaction ID should be cached');
-        
+        expectedCachedTransactionId = sessionCacheAvailable ? newTransactionId : null;
+        System.assertEquals(expectedCachedTransactionId, TritonHelper.getCachedTransactionId(), 'Updated transaction cache should match Session Cache availability');
+
         // Stop transaction and verify cache is cleared
         instance.stopTransaction();
         System.assertEquals(null, TritonHelper.getCachedTransactionId(), 'Cache should be cleared after stopping transaction');
@@ -1335,8 +1346,12 @@ private class TritonTest {
     private static void test_cache_functionality_negative() {
         Test.startTest();
         
-        // Force cache to be unavailable by simulating a Platform Cache exception
-        Cache.Org.remove('test'); // Clear any existing cache entries
+        // Clear any existing Session Cache transaction entry when available.
+        try {
+            TritonHelper.clearCachedTransactionId();
+        } catch (Exception e) {
+            // Session Cache can be unavailable in some validation orgs.
+        }
         
         // Create instance with cache disabled
         Triton instance = Triton.instance;


### PR DESCRIPTION
Fixes #33

## Summary

Fixes the Triton cache tests so they validate the same cache surface used by production transaction caching.

## Root Cause

`Triton.CACHE_AVAILABLE` and `TritonHelper` transaction cache methods use `Cache.Session`, but `TritonTest.test_cache_functionality` and its negative test were using `Cache.Org`. In orgs without a default Org Cache partition, `Cache.Org.put/remove` can fail before the tests exercise Triton's actual cache behavior.

## Changes

- Probe `Cache.Session.getKeys()` to determine whether Session Cache is available.
- Assert cached transaction behavior when Session Cache is available.
- Assert fallback behavior when Session Cache is unavailable.
- Clear transaction cache through `TritonHelper.clearCachedTransactionId()` instead of `Cache.Org.remove`.

## Validation

Validated equivalent changes in a Salesforce sandbox where the original tests failed due to a missing default Org Cache partition.