### PR TITLE
Migrate transaction ID cache from Session to Org cache

### DIFF
--- a/force-app/main/default/classes/Triton.cls
+++ b/force-app/main/default/classes/Triton.cls
@@ -104,7 +104,7 @@ global with sharing class Triton {
     private static Boolean CACHE_AVAILABLE {
         get {
             if (CACHE_AVAILABLE == null) {
-                CACHE_AVAILABLE = TritonCacheManager.sessionAvailable();
+                CACHE_AVAILABLE = TritonCacheManager.available();
             }
             return CACHE_AVAILABLE;
         }

--- a/force-app/main/default/classes/TritonCacheManager.cls
+++ b/force-app/main/default/classes/TritonCacheManager.cls
@@ -9,16 +9,16 @@
  */
 
 /**
- * Centralizes all platform cache operations (Org and Session).
- * In production, delegates to Cache.Org / Cache.Session.
- * In test context, uses static Maps to avoid platform cache limitations
+ * Centralizes all platform cache operations (Org Cache).
+ * In production, delegates to Cache.Org.
+ * In test context, uses a static Map to avoid platform cache limitations
  * where put() succeeds silently but get() returns null.
  */
 public with sharing class TritonCacheManager {
 
-    // Controls whether mock maps are used instead of real platform cache.
+    // Controls whether the mock map is used instead of real platform cache.
     // Defaults to true in test context. Tests can set to false to exercise
-    // production Cache.Org / Cache.Session code paths.
+    // production Cache.Org code paths.
     @TestVisible
     private static Boolean useMock = Test.isRunningTest();
 
@@ -57,44 +57,16 @@ public with sharing class TritonCacheManager {
         }
     }
 
-    // ─── Session Cache ────────────────────────────────────────────────
-
-    @TestVisible
-    private static Map<String, String> mockSessionCache = new Map<String, String>();
-
-    public static void sessionPut(String key, String value, Integer ttl) {
-        if (useMock) {
-            mockSessionCache.put(key, value);
-        } else {
-            Cache.Session.put(key, value, ttl);
-        }
-    }
-
-    public static String sessionGet(String key) {
-        if (useMock) {
-            return mockSessionCache.get(key);
-        }
-        return (String) Cache.Session.get(key);
-    }
-
-    public static void sessionRemove(String key) {
-        if (useMock) {
-            mockSessionCache.remove(key);
-        } else {
-            Cache.Session.remove(key);
-        }
-    }
-
     /**
-     * Checks whether Session cache is available.
+     * Checks whether Org cache is available.
      * In test context with mock enabled, always returns true.
      */
-    public static Boolean sessionAvailable() {
+    public static Boolean available() {
         if (useMock) {
             return true;
         }
         try {
-            Cache.Session.getKeys();
+            Cache.Org.getKeys();
             return true;
         } catch (Exception e) {
             return false;
@@ -106,7 +78,6 @@ public with sharing class TritonCacheManager {
     @TestVisible
     private static void resetMock() {
         mockCache.clear();
-        mockSessionCache.clear();
         useMock = true;
     }
 }

--- a/force-app/main/default/classes/TritonFlowTest.cls
+++ b/force-app/main/default/classes/TritonFlowTest.cls
@@ -700,21 +700,7 @@ private class TritonFlowTest {
         try { TritonCacheManager.get('tcm_test'); } catch (Exception e) { /* expected */ }
         try { TritonCacheManager.getKeys(); } catch (Exception e) { /* expected */ }
         try { TritonCacheManager.remove('tcm_test'); } catch (Exception e) { /* expected */ }
-
-        TritonCacheManager.resetMock(); // resets useMock = true
-    }
-
-    /**
-     * Exercises real Cache.Session code paths by disabling the mock.
-     */
-    @IsTest
-    private static void test_cache_manager_session_production_paths() {
-        TritonCacheManager.useMock = false;
-
-        try { TritonCacheManager.sessionPut('tcm_sess', 'value', 300); } catch (Exception e) { /* expected */ }
-        try { TritonCacheManager.sessionGet('tcm_sess'); } catch (Exception e) { /* expected */ }
-        try { TritonCacheManager.sessionRemove('tcm_sess'); } catch (Exception e) { /* expected */ }
-        try { TritonCacheManager.sessionAvailable(); } catch (Exception e) { /* expected */ }
+        try { TritonCacheManager.available(); } catch (Exception e) { /* expected */ }
 
         TritonCacheManager.resetMock(); // resets useMock = true
     }

--- a/force-app/main/default/classes/TritonHelper.cls
+++ b/force-app/main/default/classes/TritonHelper.cls
@@ -34,24 +34,24 @@ public with sharing class TritonHelper {
     }
     
     /**
-     * Saves transaction ID to platform cache with user-specific key
+     * Saves transaction ID to Org cache with user-specific key
      * @param transactionId Transaction ID to cache
      */
     public static void cacheTransactionId(String transactionId) {
         try {
-            TritonCacheManager.sessionPut(getUserCacheKey(), transactionId, DEFAULT_TRANSACTION_CACHE_DURATION);
+            TritonCacheManager.put(getUserCacheKey(), transactionId, DEFAULT_TRANSACTION_CACHE_DURATION);
         } catch (Exception e) {
             // Silently handle cache failures - logging system should continue without cache
         }
     }
 
     /**
-     * Retrieves transaction ID from platform cache using user-specific key
+     * Retrieves transaction ID from Org cache using user-specific key
      * @return Cached transaction ID or null if not found
      */
     public static String getCachedTransactionId() {
         try {
-            return TritonCacheManager.sessionGet(getUserCacheKey());
+            return (String) TritonCacheManager.get(getUserCacheKey());
         } catch (Exception e) {
             // Silently handle cache failures - logging system should continue without cache
             return null;
@@ -59,10 +59,10 @@ public with sharing class TritonHelper {
     }
 
     /**
-     * Clears transaction ID from platform cache
+     * Clears transaction ID from Org cache
      */
     public static void clearCachedTransactionId() {
-        TritonCacheManager.sessionRemove(getUserCacheKey());
+        TritonCacheManager.remove(getUserCacheKey());
     }
 
     // ─── Flow Log Org Cache helpers ───────────────────────────────────────

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,11 +1,26 @@
 {
   "packageDirectories": [
     {
+      "versionName": "ver 0.2",
+      "versionNumber": "0.2.0.NEXT",
       "path": "force-app",
-      "default": true
+      "default": true,
+      "package": "Pharos Triton",
+      "versionDescription": "Pharos Triton is a powerful, open-source logging framework for Salesforce, designed to integrate seamlessly with the Pharos.ai observability platform. It provides comprehensive logging capabilities across all Salesforce contexts including Apex, Flows, Lightning Web Components, and integrations.",
+      "dependencies": [
+        {
+          "package": "Pharos@2.275.0.3"
+        }
+      ]
     }
   ],
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "61.0"
+  "sourceApiVersion": "61.0",
+  "packageAliases": {
+    "Pharos Triton": "0Hog50000000pNVCAY",
+    "Pharos@2.275.0.3": "04tg7000000Dmq1AAC",
+    "Pharos Triton@0.1.0-1": "04tg50000009kjZAAQ",
+    "Pharos Triton@0.2.0-1": "04tg5000000A8YzAAK"
+  }
 }


### PR DESCRIPTION
## Summary
Replaces Session platform cache with Org platform cache for transaction ID caching.

- **Why:** Org cache is the only platform cache available in the asynchronous context (queueable/batch/future). Relying on Session cache broke transaction ID continuity across async boundaries.
- **Isolation preserved:** The transaction ID is stored under a user-specific key (`getUserCacheKey()`), so Org cache retains the per-user isolation Session cache provided — matching the user-id keying already used by the LWC caching layer.

## Changes
- `TritonCacheManager`: remove `session*` methods, add `available()` for Org cache availability checks, drop the mock session map.
- `Triton`: use `TritonCacheManager.available()` instead of `sessionAvailable()`.
- `TritonHelper`: cache / get / clear transaction ID via Org cache (`put`/`get`/`remove`).
- `TritonFlowTest`: update coverage to exercise Org cache paths.
- `sfdx-project.json`: package version/metadata bump carried over from the original branch (not part of the cache change — flagging for reviewer awareness).

## Notes
Verified there are no remaining Session cache references in `force-app`.

## Test plan
- [ ] Run Apex test suite (incl. `TritonFlowTest`) and confirm coverage passes
- [ ] Verify transaction ID persists across an async (queueable/batch) boundary
- [ ] Confirm reviewer intent for the `sfdx-project.json` packaging bump