### PR TITLE
LOG-2604: Add user id and component to log level matching

### DIFF
--- a/force-app/main/default/classes/Triton.cls
+++ b/force-app/main/default/classes/Triton.cls
@@ -54,17 +54,17 @@ global with sharing class Triton {
     }
 
     /**
-    * Helper map for storing current log levels
+    * Cached, parsed Log_Level__mdt rules used to decide whether a log is verbose
+    * enough to be persisted. Lazily built from LOG_LEVELS_MDT and reset by tests
+    * by assigning null.
     */
     @TestVisible
-    private static Map<String, TritonTypes.Level> LOG_LEVELS {
+    private static List<LogLevelRule> LOG_LEVELS {
         get {
             if (LOG_LEVELS == null) {
-                LOG_LEVELS = new Map<String, TritonTypes.Level>();
-                for(Log_Level__mdt ll : LOG_LEVELS_MDT) {
-                    LOG_LEVELS.put(
-                            TritonHelper.buildLogLevelKey(ll.Category__c, ll.Type__c, ll.Area__c),
-                            TritonTypes.Level.valueOf(ll.Level__c));
+                LOG_LEVELS = new List<LogLevelRule>();
+                for (Log_Level__mdt ll : LOG_LEVELS_MDT) {
+                    LOG_LEVELS.add(new LogLevelRule(ll));
                 }
             }
             return LOG_LEVELS;
@@ -329,34 +329,108 @@ global with sharing class Triton {
     public static void finest(TritonBuilder builder) { log(builder.finest()); }
 
     /**
-    * Checks if a log should be persisted based on the current log level
+    * Checks if a log should be persisted based on the configured log levels.
+    *
+    * A Log_Level__mdt record "targets" a log when every attribute it specifies
+    * (Category, Type, Area, User Id, Component Name) matches the log. Unspecified
+    * (null) attributes act as wildcards, so a record can scope a level as broadly
+    * (a global default) or as narrowly (a single user or component) as needed.
+    *
+    * A log is allowed when either no configured level targets it, or at least one
+    * targeting level is verbose enough (its level is greater than or equal to the
+    * log's level).
     * @param log -- Pharos log record to be saved
     */
     public static Boolean isLogAllowedForLogLevel(pharos__Log__c log) {
         if (String.isBlank(log.Log_Level__c) || LOG_LEVELS.isEmpty()) return true;
 
-        //a set of possible mapping permutations
-        //these will be checked in the same order as this list
-        String[] permutations = new String[] {
-                TritonHelper.buildLogLevelKey(log.pharos__Category__c, log.pharos__Type__c, log.pharos__Area__c),
-                TritonHelper.buildLogLevelKey(log.pharos__Category__c, log.pharos__Type__c, null),
-                TritonHelper.buildLogLevelKey(log.pharos__Category__c, null, log.pharos__Area__c),
-                TritonHelper.buildLogLevelKey(null, log.pharos__Type__c, log.pharos__Area__c),
-                TritonHelper.buildLogLevelKey(null, null, log.pharos__Area__c),
-                TritonHelper.buildLogLevelKey(null, log.pharos__Type__c, null),
-                TritonHelper.buildLogLevelKey(log.pharos__Category__c, null, null),
-                TritonHelper.buildLogLevelKey(null, null, null)
-        };
-
+        String logUserId = normalizeUserId(log.pharos__User_Id__c);
+        String logComponent = getComponentName(log);
         TritonTypes.Level currentLevel = TritonTypes.Level.valueOf(log.Log_Level__c);
-        Boolean allPermutationsDontExistInMdt = true;
-        for (String key : permutations) {
-            if (LOG_LEVELS.containsKey(key)) {
-                if (TritonHelper.compareLevel(LOG_LEVELS.get(key), currentLevel)) return true;
-            }
-            allPermutationsDontExistInMdt = allPermutationsDontExistInMdt && !LOG_LEVELS.containsKey(key);
+
+        Boolean anyLevelTargetsLog = false;
+        for (LogLevelRule rule : LOG_LEVELS) {
+            if (!rule.targets(log, logUserId, logComponent)) continue;
+            anyLevelTargetsLog = true;
+            if (TritonHelper.compareLevel(rule.level, currentLevel)) return true;
         }
 
-        return allPermutationsDontExistInMdt;
+        // No configured level targets this log -- allow it through by default.
+        return !anyLevelTargetsLog;
+    }
+
+    /**
+    * Resolves the component name used for log level matching.
+    * Flows are identified by their API name; Apex/LWC by the class/component
+    * portion of the Apex Name (the text before the first '.').
+    *
+    * Note: this runs during the log level check, before prepareForLogging derives
+    * the operation from the stack trace. The component is therefore only available
+    * when it is known at log() time -- LWC logs, Flow logs, or Apex logs with an
+    * explicit operation. Apex logs relying on stack-trace-derived naming will have
+    * a blank component here and are not matched by component-scoped levels.
+    * @param log -- Pharos log record being evaluated
+    * @return the component name, or null/blank when it cannot be determined
+    */
+    @TestVisible
+    private static String getComponentName(pharos__Log__c log) {
+        if (String.isNotBlank(log.pharos__Flow_API_Name__c)) return log.pharos__Flow_API_Name__c;
+
+        String apexName = log.pharos__Apex_Name__c;
+        if (String.isBlank(apexName)) return apexName;
+        Integer dotIndex = apexName.indexOf('.');
+        return dotIndex == -1 ? apexName : apexName.substring(0, dotIndex);
+    }
+
+    /**
+    * Salesforce Ids are 18 characters in Apex, but Log Level metadata stores the
+    * 15-character form. Matching is performed on the case-sensitive 15-character
+    * prefix so both representations line up.
+    * @param userId -- a 15 or 18 character user Id (or null)
+    * @return the 15-character prefix, or the original value when shorter/blank
+    */
+    @TestVisible
+    private static String normalizeUserId(String userId) {
+        return String.isNotBlank(userId) && userId.length() > 15 ? userId.substring(0, 15) : userId;
+    }
+
+    /**
+    * In-memory representation of a Log_Level__mdt record, parsed once and cached
+    * so that log level checks avoid re-reading and re-parsing metadata per log.
+    */
+    private class LogLevelRule {
+        private final String category;
+        private final String type;
+        private final String area;
+        private final String userId;
+        private final String component;
+        private final TritonTypes.Level level;
+
+        private LogLevelRule(Log_Level__mdt mdt) {
+            this.category = mdt.Category__c;
+            this.type = mdt.Type__c;
+            this.area = mdt.Area__c;
+            this.userId = normalizeUserId(mdt.User_Id__c);
+            this.component = mdt.Component_Name__c;
+            this.level = TritonTypes.Level.valueOf(mdt.Level__c);
+        }
+
+        /**
+        * True when every attribute specified on this rule matches the log.
+        * Null (unspecified) rule attributes are treated as wildcards.
+        */
+        private Boolean targets(pharos__Log__c log, String logUserId, String logComponent) {
+            return matches(category, log.pharos__Category__c)
+                && matches(type, log.pharos__Type__c)
+                && matches(area, log.pharos__Area__c)
+                && matches(userId, logUserId)
+                && matches(component, logComponent);
+        }
+
+        // String.equals is case-sensitive and null-safe, preserving the
+        // case-sensitivity required for 15-character Salesforce Ids.
+        private Boolean matches(String ruleValue, String logValue) {
+            return ruleValue == null || ruleValue.equals(logValue);
+        }
     }
 }

--- a/force-app/main/default/classes/TritonHelper.cls
+++ b/force-app/main/default/classes/TritonHelper.cls
@@ -148,17 +148,6 @@ public with sharing class TritonHelper {
     }
 
     /**
-    * Creates a key for log level based on:
-    * @param category -- log category field
-    * @param tye -- log type field
-    * @param area -- log functional area field
-    * @return -- a string with values in the following format: Category:{0};Type:{1};Area:{2}
-    */
-    public static String buildLogLevelKey(String category, String type, String area) {
-        return String.format('Category:{0};Type:{1};Area:{2}', new String[]{category, type, area});
-    }
-
-    /**
     * Compares 2 log levels.
     * @param value -- this is the value compared against
     * @param toCompare -- comparison performed against this value

--- a/force-app/main/default/classes/TritonTest.cls
+++ b/force-app/main/default/classes/TritonTest.cls
@@ -34,10 +34,9 @@ private class TritonTest {
         Log_Level__mdt ll = new Log_Level__mdt();
         ll.Level__c = TritonTypes.Level.DEBUG.name();
         Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{ll};
+        Triton.LOG_LEVELS = null;
 
-        System.assertEquals(1, Triton.LOG_LEVELS.size());
-        System.assertEquals('Category:null;Type:null;Area:null', new List<String>(Triton.LOG_LEVELS.keySet())[0]);
-        System.assertEquals(TritonTypes.Level.DEBUG, Triton.LOG_LEVELS.get('Category:null;Type:null;Area:null'));
+        System.assertEquals(1, Triton.LOG_LEVELS.size(), 'Expected a single parsed log level rule');
     }
 
     @IsTest
@@ -84,6 +83,7 @@ private class TritonTest {
         categoryAndAreaLevel.Area__c = TritonTypes.Area.Community.name();
 
         Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{globalLevel, categoryLevel, categoryAndAreaLevel};
+        Triton.LOG_LEVELS = null;
     }
 
     @IsTest
@@ -92,12 +92,7 @@ private class TritonTest {
 
         setupLogLevelsMap();
 
-        System.assertEquals(3, Triton.LOG_LEVELS.size());
-        System.assertEquals(TritonTypes.Level.DEBUG, Triton.LOG_LEVELS.get('Category:null;Type:null;Area:null'));
-        System.assertEquals(TritonTypes.Level.FINE, Triton.LOG_LEVELS.get('Category:Event;Type:null;Area:null'));
-        System.assertEquals(TritonTypes.Level.FINEST, Triton.LOG_LEVELS.get('Category:Event;Type:null;Area:Community'));
-
-
+        System.assertEquals(3, Triton.LOG_LEVELS.size(), 'Expected three parsed log level rules');
 
         Test.startTest();
         Triton.logNow(Triton.t.category(TritonTypes.Category.Event).type(TritonTypes.Type.Backend).area(TritonTypes.Area.Community).summary('some event').details('error details').level(TritonTypes.Level.FINEST));
@@ -117,6 +112,187 @@ private class TritonTest {
         Test.stopTest();
 
         System.assertEquals(0, [SELECT COUNT() FROM pharos__Log__c WHERE pharos__Category__c = :TritonTypes.Category.Event.name()]);
+    }
+
+    // A user-scoped log level record used by the user id tests below.
+    private static void setupUserIdLogLevel(Id userId) {
+        Log_Level__mdt userLevel = new Log_Level__mdt();
+        userLevel.Level__c = TritonTypes.Level.DEBUG.name();
+        userLevel.User_Id__c = userId;
+
+        Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{ userLevel };
+        Triton.LOG_LEVELS = null;
+    }
+
+    @IsTest
+    private static void test_log_level_by_user_id_positive() {
+        TritonTestFactory.assertNoLogs();
+
+        // Level defined only for the current user, allowing DEBUG and above.
+        setupUserIdLogLevel(UserInfo.getUserId());
+
+        Test.startTest();
+        Triton.logNow(Triton.t.category(TritonTypes.Category.Event).type(TritonTypes.Type.Backend).area(TritonTypes.Area.Community)
+            .summary('some event').details('error details').userId(UserInfo.getUserId()).level(TritonTypes.Level.DEBUG));
+        Test.stopTest();
+
+        TritonTestFactory.assertSingleLog(TritonTypes.Category.Event);
+    }
+
+    @IsTest
+    private static void test_log_level_by_user_id_negative() {
+        TritonTestFactory.assertNoLogs();
+
+        // The user-scoped level allows only DEBUG and above; a FINE log for that
+        // same user must be filtered out.
+        setupUserIdLogLevel(UserInfo.getUserId());
+
+        Test.startTest();
+        Triton.logNow(Triton.t.category(TritonTypes.Category.Event).type(TritonTypes.Type.Backend).area(TritonTypes.Area.Community)
+            .summary('some event').details('error details').userId(UserInfo.getUserId()).level(TritonTypes.Level.FINE));
+        Test.stopTest();
+
+        System.assertEquals(0, [SELECT COUNT() FROM pharos__Log__c WHERE pharos__Category__c = :TritonTypes.Category.Event.name()]);
+    }
+
+    @IsTest
+    private static void test_log_level_by_user_id_different_user() {
+        TritonTestFactory.assertNoLogs();
+
+        // Level is scoped to a different user, so it must not target the current
+        // user's logs -- the FINE log falls through the default-allow path.
+        setupUserIdLogLevel('005000000000001');
+
+        Test.startTest();
+        Triton.logNow(Triton.t.category(TritonTypes.Category.Event).type(TritonTypes.Type.Backend).area(TritonTypes.Area.Community)
+            .summary('some event').details('error details').userId(UserInfo.getUserId()).level(TritonTypes.Level.FINE));
+        Test.stopTest();
+
+        TritonTestFactory.assertSingleLog(TritonTypes.Category.Event);
+    }
+
+    @IsTest
+    private static void test_log_level_by_component_apex_positive() {
+        TritonTestFactory.assertNoLogs();
+
+        // Level defined only for the 'MyComponent' Apex class, allowing DEBUG and above.
+        Log_Level__mdt componentLevel = new Log_Level__mdt();
+        componentLevel.Level__c = TritonTypes.Level.DEBUG.name();
+        componentLevel.Component_Name__c = 'MyComponent';
+        Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{ componentLevel };
+        Triton.LOG_LEVELS = null;
+
+        Test.startTest();
+        // Apex Name is Class.Method; the class portion must match the component name.
+        Triton.logNow(Triton.t.category(TritonTypes.Category.Event).type(TritonTypes.Type.Backend).area(TritonTypes.Area.Community)
+            .summary('some event').details('error details').operation('MyComponent.someMethod').level(TritonTypes.Level.DEBUG));
+        Test.stopTest();
+
+        TritonTestFactory.assertSingleLog(TritonTypes.Category.Event);
+    }
+
+    @IsTest
+    private static void test_log_level_by_component_apex_negative() {
+        TritonTestFactory.assertNoLogs();
+
+        Log_Level__mdt componentLevel = new Log_Level__mdt();
+        componentLevel.Level__c = TritonTypes.Level.DEBUG.name();
+        componentLevel.Component_Name__c = 'MyComponent';
+        Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{ componentLevel };
+        Triton.LOG_LEVELS = null;
+
+        Test.startTest();
+        // Component matches but FINE is more verbose than the allowed DEBUG.
+        Triton.logNow(Triton.t.category(TritonTypes.Category.Event).type(TritonTypes.Type.Backend).area(TritonTypes.Area.Community)
+            .summary('some event').details('error details').operation('MyComponent.someMethod').level(TritonTypes.Level.FINE));
+        Test.stopTest();
+
+        System.assertEquals(0, [SELECT COUNT() FROM pharos__Log__c WHERE pharos__Category__c = :TritonTypes.Category.Event.name()]);
+    }
+
+    @IsTest
+    private static void test_log_level_by_component_flow() {
+        TritonTestFactory.assertNoLogs();
+
+        // For flows the component is identified by the Flow API name, which takes
+        // precedence over the Apex Name.
+        Log_Level__mdt componentLevel = new Log_Level__mdt();
+        componentLevel.Level__c = TritonTypes.Level.DEBUG.name();
+        componentLevel.Component_Name__c = 'My_Flow';
+        Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{ componentLevel };
+        Triton.LOG_LEVELS = null;
+
+        Test.startTest();
+        Triton.logNow(Triton.t.category(TritonTypes.Category.Event).type(TritonTypes.Type.Backend).area(TritonTypes.Area.Community)
+            .summary('some event').details('error details').flowApiName('My_Flow').operation('Some.Apex').level(TritonTypes.Level.DEBUG));
+        Test.stopTest();
+
+        TritonTestFactory.assertSingleLog(TritonTypes.Category.Event);
+    }
+
+    @IsTest
+    private static void test_log_level_all_attributes() {
+        TritonTestFactory.assertNoLogs();
+
+        // A single, fully-specified rule so the assertion isolates the new
+        // user id / component matching (nothing broader can match instead).
+        Log_Level__mdt allLevel = new Log_Level__mdt();
+        allLevel.Level__c = TritonTypes.Level.FINER.name();
+        allLevel.Category__c = TritonTypes.Category.Event.name();
+        allLevel.Type__c = TritonTypes.Type.DMLResult.name();
+        allLevel.Area__c = TritonTypes.Area.Community.name();
+        allLevel.User_Id__c = UserInfo.getUserId();
+        allLevel.Component_Name__c = 'TestComponentName';
+        Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{ allLevel };
+        Triton.LOG_LEVELS = null;
+
+        Test.startTest();
+        // Matches every attribute at exactly the allowed level.
+        Triton.logNow(Triton.t.category(TritonTypes.Category.Event).type(TritonTypes.Type.DMLResult).area(TritonTypes.Area.Community)
+            .summary('some event').details('error details').userId(UserInfo.getUserId()).operation('TestComponentName').level(TritonTypes.Level.FINER));
+        // Same attributes but a different component -> no rule targets it -> allowed by default.
+        Triton.logNow(Triton.t.category(TritonTypes.Category.Event).type(TritonTypes.Type.DMLResult).area(TritonTypes.Area.Community)
+            .summary('other event').details('error details').userId(UserInfo.getUserId()).operation('OtherComponent').level(TritonTypes.Level.FINER));
+        Test.stopTest();
+
+        List<pharos__Log__c> logs = [
+            SELECT pharos__User_Id__c, pharos__Apex_Name__c
+            FROM pharos__Log__c
+            WHERE pharos__Category__c = :TritonTypes.Category.Event.name()
+            ORDER BY pharos__Apex_Name__c
+        ];
+        System.assertEquals(2, logs.size(), 'Both the targeted (allowed) and untargeted (default-allowed) logs should persist');
+        System.assertEquals('OtherComponent', logs.get(0).pharos__Apex_Name__c);
+        System.assertEquals('TestComponentName', logs.get(1).pharos__Apex_Name__c);
+        System.assertEquals(UserInfo.getUserId(), logs.get(1).pharos__User_Id__c);
+    }
+
+    @IsTest
+    private static void test_get_component_name() {
+        // Flow API name takes precedence.
+        pharos__Log__c flowLog = new pharos__Log__c(pharos__Flow_API_Name__c = 'My_Flow', pharos__Apex_Name__c = 'Some.Apex');
+        System.assertEquals('My_Flow', Triton.getComponentName(flowLog));
+
+        // Apex name: class portion before the first dot.
+        pharos__Log__c apexLog = new pharos__Log__c(pharos__Apex_Name__c = 'MyClass.myMethod');
+        System.assertEquals('MyClass', Triton.getComponentName(apexLog));
+
+        // Apex name without a dot is returned as-is.
+        pharos__Log__c plainLog = new pharos__Log__c(pharos__Apex_Name__c = 'MyClass');
+        System.assertEquals('MyClass', Triton.getComponentName(plainLog));
+
+        // Nothing to resolve.
+        System.assertEquals(null, Triton.getComponentName(new pharos__Log__c()));
+    }
+
+    @IsTest
+    private static void test_normalize_user_id() {
+        Id userId = UserInfo.getUserId();
+        System.assertEquals(String.valueOf(userId).substring(0, 15), Triton.normalizeUserId(userId),
+            '18-character Id should be truncated to its 15-character prefix');
+        System.assertEquals('015CHAR00000000', Triton.normalizeUserId('015CHAR00000000'),
+            '15-character value should be returned unchanged');
+        System.assertEquals(null, Triton.normalizeUserId(null));
     }
 
     @IsTest

--- a/force-app/main/default/objects/Log_Level__mdt/fields/Component_Name__c.field-meta.xml
+++ b/force-app/main/default/objects/Log_Level__mdt/fields/Component_Name__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Component_Name__c</fullName>
+    <description>Optional. Scopes this log level to a single component. For Apex enter the class name, for LWC the component name, for Flows the Flow API name. Leave blank to apply to all components. Note: the component must be known when the log is created (LWC/Flow logs, or Apex logs with an explicit operation). Apex logs whose operation is derived from the stack trace are not matched by component-scoped levels.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>Apex class name, LWC component name, or Flow API name this log level applies to. Leave blank to apply to all components. Apex logs without an explicit operation are not matched.</inlineHelpText>
+    <label>Component Name</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Log_Level__mdt/fields/User_Id__c.field-meta.xml
+++ b/force-app/main/default/objects/Log_Level__mdt/fields/User_Id__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>User_Id__c</fullName>
+    <description>Optional. Scopes this log level to a single user. Enter the 15-character Salesforce User Id. Matching is performed on the case-sensitive 15-character Id prefix.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>15-character Salesforce User Id this log level applies to. Leave blank to apply to all users.</inlineHelpText>
+    <label>User Id</label>
+    <length>15</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## Summary
- Adds `User_Id__c` and `Component_Name__c` fields to `Log_Level__mdt`, so log levels can be scoped by user or component (Apex class, LWC component, or Flow API name) in addition to Category/Type/Area. Unspecified attributes act as wildcards.
- Replaces the per-log permutation-key generation with direct iteration over cached, parsed log level rules (`LogLevelRule`). This removes the recursive combination builder, nested-list allocations, redundant copy loop, and the mutable static counter — no string building on the hot path.
- Matches user Ids on their case-sensitive 15-character prefix (via `String.equals`), so the 15-char metadata value lines up with the 18-char runtime Id.

## Behavior notes
- Semantics are preserved: a log is allowed when no configured level targets it, or when at least one targeting level is verbose enough.
- Component-scoped levels require the component to be known at log time (LWC logs, Flow logs, or Apex logs with an explicit operation). Apex logs whose operation is derived from the stack trace are not matched by component-scoped levels — documented in the `Component_Name__c` field help text and in `getComponentName`.

## Tests
- Rewrote the log-level mapping tests to assert behavior rather than internal keys.
- Added focused coverage: user-id positive/negative/different-user, component matching for Apex and Flow (API-name precedence), a fully-specified rule, and unit tests for `getComponentName` and `normalizeUserId`.

## Test plan
- [ ] Run the Triton Apex test suite in a scratch org / CI (no org available locally).
- [ ] Deploy the two new `Log_Level__mdt` fields and verify a user- and component-scoped level behaves as expected.