### PR TITLE
Add global switches to disable Triton logging and the delayed Flow flush batch

### DIFF
--- a/force-app/main/default/classes/Triton.cls
+++ b/force-app/main/default/classes/Triton.cls
@@ -301,6 +301,10 @@ global with sharing class Triton {
     * @param builder TritonBuilder instance containing log details
     */
     public static void log(TritonBuilder builder) {
+        if (TritonHelper.isLoggingDisabled()) {
+            return;
+        }
+
         pharos__Log__c log = builder.build();
 
         if (!isLogAllowedForLogLevel(log)) {

--- a/force-app/main/default/classes/Triton.cls
+++ b/force-app/main/default/classes/Triton.cls
@@ -53,28 +53,6 @@ global with sharing class Triton {
         private set;
     }
 
-    /**
-    * Cached, parsed Log_Level__mdt rules used to decide whether a log is verbose
-    * enough to be persisted. Lazily built from LOG_LEVELS_MDT and reset by tests
-    * by assigning null.
-    */
-    @TestVisible
-    private static List<LogLevelRule> LOG_LEVELS {
-        get {
-            if (LOG_LEVELS == null) {
-                LOG_LEVELS = new List<LogLevelRule>();
-                for (Log_Level__mdt ll : LOG_LEVELS_MDT) {
-                    LOG_LEVELS.add(new LogLevelRule(ll));
-                }
-            }
-            return LOG_LEVELS;
-        }
-        set;
-    }
-
-    @TestVisible
-    private static Log_Level__mdt[] LOG_LEVELS_MDT = Log_Level__mdt.getAll().values();
-
     private static TritonBuilder template {
         get {
             if (template == null) {
@@ -301,13 +279,13 @@ global with sharing class Triton {
     * @param builder TritonBuilder instance containing log details
     */
     public static void log(TritonBuilder builder) {
-        if (TritonHelper.isLoggingDisabled()) {
+        if (TritonHelper.Config.isLoggingDisabled()) {
             return;
         }
 
         pharos__Log__c log = builder.build();
 
-        if (!isLogAllowedForLogLevel(log)) {
+        if (!TritonHelper.Config.isLogAllowed(log)) {
             return;
         }
 
@@ -332,109 +310,4 @@ global with sharing class Triton {
     public static void finer(TritonBuilder builder) { log(builder.finer()); }
     public static void finest(TritonBuilder builder) { log(builder.finest()); }
 
-    /**
-    * Checks if a log should be persisted based on the configured log levels.
-    *
-    * A Log_Level__mdt record "targets" a log when every attribute it specifies
-    * (Category, Type, Area, User Id, Component Name) matches the log. Unspecified
-    * (null) attributes act as wildcards, so a record can scope a level as broadly
-    * (a global default) or as narrowly (a single user or component) as needed.
-    *
-    * A log is allowed when either no configured level targets it, or at least one
-    * targeting level is verbose enough (its level is greater than or equal to the
-    * log's level).
-    * @param log -- Pharos log record to be saved
-    */
-    public static Boolean isLogAllowedForLogLevel(pharos__Log__c log) {
-        if (String.isBlank(log.Log_Level__c) || LOG_LEVELS.isEmpty()) return true;
-
-        String logUserId = normalizeUserId(log.pharos__User_Id__c);
-        String logComponent = getComponentName(log);
-        TritonTypes.Level currentLevel = TritonTypes.Level.valueOf(log.Log_Level__c);
-
-        Boolean anyLevelTargetsLog = false;
-        for (LogLevelRule rule : LOG_LEVELS) {
-            if (!rule.targets(log, logUserId, logComponent)) continue;
-            anyLevelTargetsLog = true;
-            if (TritonHelper.compareLevel(rule.level, currentLevel)) return true;
-        }
-
-        // No configured level targets this log -- allow it through by default.
-        return !anyLevelTargetsLog;
-    }
-
-    /**
-    * Resolves the component name used for log level matching.
-    * Flows are identified by their API name; Apex/LWC by the class/component
-    * portion of the Apex Name (the text before the first '.').
-    *
-    * Note: this runs during the log level check, before prepareForLogging derives
-    * the operation from the stack trace. The component is therefore only available
-    * when it is known at log() time -- LWC logs, Flow logs, or Apex logs with an
-    * explicit operation. Apex logs relying on stack-trace-derived naming will have
-    * a blank component here and are not matched by component-scoped levels.
-    * @param log -- Pharos log record being evaluated
-    * @return the component name, or null/blank when it cannot be determined
-    */
-    @TestVisible
-    private static String getComponentName(pharos__Log__c log) {
-        if (String.isNotBlank(log.pharos__Flow_API_Name__c)) return log.pharos__Flow_API_Name__c;
-
-        String apexName = log.pharos__Apex_Name__c;
-        if (String.isBlank(apexName)) return apexName;
-        Integer dotIndex = apexName.indexOf('.');
-        return dotIndex == -1 ? apexName : apexName.substring(0, dotIndex);
-    }
-
-    /**
-    * Salesforce Ids are 18 characters in Apex, but Log Level metadata stores the
-    * 15-character form. Matching is performed on the case-sensitive 15-character
-    * prefix so both representations line up.
-    * @param userId -- a 15 or 18 character user Id (or null)
-    * @return the 15-character prefix, or the original value when shorter/blank
-    */
-    @TestVisible
-    private static String normalizeUserId(String userId) {
-        return String.isNotBlank(userId) && userId.length() > 15 ? userId.substring(0, 15) : userId;
-    }
-
-    /**
-    * In-memory representation of a Log_Level__mdt record, parsed once and cached
-    * so that log level checks avoid re-reading and re-parsing metadata per log.
-    */
-    private class LogLevelRule {
-        private final String category;
-        private final String type;
-        private final String area;
-        private final String userId;
-        private final String component;
-        private final TritonTypes.Level level;
-
-        private LogLevelRule(Log_Level__mdt mdt) {
-            this.category = mdt.Category__c;
-            this.type = mdt.Type__c;
-            this.area = mdt.Area__c;
-            this.userId = normalizeUserId(mdt.User_Id__c);
-            this.component = mdt.Component_Name__c;
-            this.level = TritonTypes.Level.valueOf(mdt.Level__c);
-        }
-
-        /**
-        * True when every attribute specified on this rule matches the log.
-        * Null (unspecified) rule attributes are treated as wildcards.
-        */
-        private Boolean targets(pharos__Log__c log, String logUserId, String logComponent) {
-            return matches(category, log.pharos__Category__c)
-                && matches(type, log.pharos__Type__c)
-                && matches(area, log.pharos__Area__c)
-                && matches(userId, logUserId)
-                && matches(component, logComponent);
-        }
-
-        // String.equals is case-sensitive and null-safe, preserving the
-        // case-sensitivity required for 15-character Salesforce Ids.
-        private Boolean matches(String ruleValue, String logValue) {
-            return ruleValue == null || ruleValue.equals(logValue);
-        }
-    }
 }

--- a/force-app/main/default/classes/TritonFlow.cls
+++ b/force-app/main/default/classes/TritonFlow.cls
@@ -37,7 +37,7 @@ global with sharing class TritonFlow {
     public static List<FlowLogOutput> log(List<FlowLog> flowLogs) {
         // Master kill switch: skip all log construction, but preserve the
         // invocable contract of one output per input.
-        if (TritonHelper.isLoggingDisabled()) {
+        if (TritonHelper.Config.isLoggingDisabled()) {
             List<FlowLogOutput> disabledOutputs = new List<FlowLogOutput>();
             for (Integer i = 0; i < flowLogs.size(); i++) {
                 disabledOutputs.add(new FlowLogOutput());
@@ -52,7 +52,7 @@ global with sharing class TritonFlow {
         }
         // When the deferred batch is disabled, publish synchronously in-transaction.
         // Triton.flush() drains and publishes its own buffer — no logs are lost.
-        if (TritonHelper.isFlowFlushBatchDisabled()) {
+        if (TritonHelper.Config.isFlowFlushBatchDisabled()) {
             Triton.flush();
             return flowLogOutputs;
         }

--- a/force-app/main/default/classes/TritonFlow.cls
+++ b/force-app/main/default/classes/TritonFlow.cls
@@ -35,6 +35,16 @@ global with sharing class TritonFlow {
                     Label='Log' 
                     Description='Creates a log for a flow or process builder')
     public static List<FlowLogOutput> log(List<FlowLog> flowLogs) {
+        // Master kill switch: skip all log construction, but preserve the
+        // invocable contract of one output per input.
+        if (TritonHelper.isLoggingDisabled()) {
+            List<FlowLogOutput> disabledOutputs = new List<FlowLogOutput>();
+            for (Integer i = 0; i < flowLogs.size(); i++) {
+                disabledOutputs.add(new FlowLogOutput());
+            }
+            return disabledOutputs;
+        }
+
         List<FlowLogOutput> flowLogOutputs = new List<FlowLogOutput>();
         for (FlowLog flowLog : flowLogs) {
             FlowLogOutput result = processFlowLog(flowLog);

--- a/force-app/main/default/classes/TritonFlow.cls
+++ b/force-app/main/default/classes/TritonFlow.cls
@@ -50,6 +50,13 @@ global with sharing class TritonFlow {
             FlowLogOutput result = processFlowLog(flowLog);
             flowLogOutputs.add(result);
         }
+        // When the deferred batch is disabled, publish synchronously in-transaction.
+        // Triton.flush() drains and publishes its own buffer — no logs are lost.
+        if (TritonHelper.isFlowFlushBatchDisabled()) {
+            Triton.flush();
+            return flowLogOutputs;
+        }
+
         // Drain buffered logs and defer to batch flush instead of immediate publish.
         // addLogs handles all failure cases internally — no logs are ever lost.
         List<pharos__Log__c> buffered = Triton.drain();

--- a/force-app/main/default/classes/TritonFlowTest.cls
+++ b/force-app/main/default/classes/TritonFlowTest.cls
@@ -704,4 +704,24 @@ private class TritonFlowTest {
 
         TritonCacheManager.resetMock(); // resets useMock = true
     }
+
+    @IsTest
+    private static void test_flow_master_switch_disables_logging() {
+        TritonTestFactory.assertNoLogs();
+        TritonTestFactory.resetFlowState();
+        TritonHelper.settings = new TritonSettings__c(Disable_Logging__c = true);
+
+        Test.startTest();
+        List<TritonFlow.FlowLogOutput> outputs = TritonFlow.log(
+            new List<TritonFlow.FlowLog>{
+                TritonTestFactory.makeFlowLog('a'),
+                TritonTestFactory.makeFlowLog('b')
+            });
+        TritonTestFactory.flushCachedFlowLogs();
+        Test.stopTest();
+
+        System.assertEquals(2, outputs.size(),
+            'One output per input must be returned even when logging is disabled');
+        TritonTestFactory.assertNoLogs();
+    }
 }

--- a/force-app/main/default/classes/TritonFlowTest.cls
+++ b/force-app/main/default/classes/TritonFlowTest.cls
@@ -724,4 +724,44 @@ private class TritonFlowTest {
             'One output per input must be returned even when logging is disabled');
         TritonTestFactory.assertNoLogs();
     }
+
+    @IsTest
+    private static void test_flow_batch_disabled_flushes_immediately() {
+        TritonTestFactory.assertNoLogs();
+        TritonTestFactory.resetFlowState();
+        TritonHelper.settings = new TritonSettings__c(Disable_Flow_Flush_Batch__c = true);
+
+        Test.startTest();
+        TritonFlow.log(new List<TritonFlow.FlowLog>{
+            TritonTestFactory.makeFlowLog('immediate')
+        });
+        // Disabled batch must NOT defer to Org Cache — nothing buffered for a batch.
+        System.assert(TritonHelper.getFlowLogCacheKeys().isEmpty(),
+            'Disabled batch should not write Flow logs to Org Cache');
+        System.assertEquals(0, TritonTestFactory.countActiveFlowFlushBatchJobs(),
+            'No deferred batch job should be scheduled when the batch is disabled');
+        Test.stopTest();
+
+        // The immediately-flushed log is delivered by pharos at stopTest.
+        TritonTestFactory.assertLogCount(1);
+    }
+
+    @IsTest
+    private static void test_flow_batch_enabled_defers_flush() {
+        TritonTestFactory.assertNoLogs();
+        TritonTestFactory.resetFlowState();
+        TritonHelper.settings = new TritonSettings__c(Disable_Flow_Flush_Batch__c = false);
+
+        Test.startTest();
+        TritonFlow.log(new List<TritonFlow.FlowLog>{
+            TritonTestFactory.makeFlowLog('deferred')
+        });
+        // Enabled batch defers: Flow logs are buffered in Org Cache for the batch.
+        System.assert(!TritonHelper.getFlowLogCacheKeys().isEmpty(),
+            'Enabled batch should buffer Flow logs in Org Cache for deferred flush');
+        TritonTestFactory.flushCachedFlowLogs();
+        Test.stopTest();
+
+        TritonTestFactory.assertLogCount(1);
+    }
 }

--- a/force-app/main/default/classes/TritonFlowTest.cls
+++ b/force-app/main/default/classes/TritonFlowTest.cls
@@ -320,8 +320,8 @@ private class TritonFlowTest {
 
         Log_Level__mdt ll = new Log_Level__mdt();
         ll.Level__c = TritonTypes.Level.DEBUG.name();
-        Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{ ll };
-        Triton.LOG_LEVELS = null;
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ ll };
+        TritonHelper.Config.logLevels = null;
 
         TritonFlow.FlowLog flowLog = TritonTestFactory.makeFlowLog('should-be-filtered');
         flowLog.level = 'FINE';
@@ -709,7 +709,7 @@ private class TritonFlowTest {
     private static void test_flow_master_switch_disables_logging() {
         TritonTestFactory.assertNoLogs();
         TritonTestFactory.resetFlowState();
-        TritonHelper.settings = new TritonSettings__c(Disable_Logging__c = true);
+        TritonHelper.Config.settings = new TritonSettings__c(Disable_Logging__c = true);
 
         Test.startTest();
         List<TritonFlow.FlowLogOutput> outputs = TritonFlow.log(
@@ -729,7 +729,7 @@ private class TritonFlowTest {
     private static void test_flow_batch_disabled_flushes_immediately() {
         TritonTestFactory.assertNoLogs();
         TritonTestFactory.resetFlowState();
-        TritonHelper.settings = new TritonSettings__c(Disable_Flow_Flush_Batch__c = true);
+        TritonHelper.Config.settings = new TritonSettings__c(Disable_Flow_Flush_Batch__c = true);
 
         Test.startTest();
         TritonFlow.log(new List<TritonFlow.FlowLog>{
@@ -750,7 +750,7 @@ private class TritonFlowTest {
     private static void test_flow_batch_enabled_defers_flush() {
         TritonTestFactory.assertNoLogs();
         TritonTestFactory.resetFlowState();
-        TritonHelper.settings = new TritonSettings__c(Disable_Flow_Flush_Batch__c = false);
+        TritonHelper.Config.settings = new TritonSettings__c(Disable_Flow_Flush_Batch__c = false);
 
         Test.startTest();
         TritonFlow.log(new List<TritonFlow.FlowLog>{
@@ -769,7 +769,7 @@ private class TritonFlowTest {
     private static void test_flow_both_switches_on_persists_nothing() {
         TritonTestFactory.assertNoLogs();
         TritonTestFactory.resetFlowState();
-        TritonHelper.settings = new TritonSettings__c(
+        TritonHelper.Config.settings = new TritonSettings__c(
             Disable_Logging__c = true,
             Disable_Flow_Flush_Batch__c = true
         );

--- a/force-app/main/default/classes/TritonFlowTest.cls
+++ b/force-app/main/default/classes/TritonFlowTest.cls
@@ -764,4 +764,23 @@ private class TritonFlowTest {
 
         TritonTestFactory.assertLogCount(1);
     }
+
+    @IsTest
+    private static void test_flow_both_switches_on_persists_nothing() {
+        TritonTestFactory.assertNoLogs();
+        TritonTestFactory.resetFlowState();
+        TritonHelper.settings = new TritonSettings__c(
+            Disable_Logging__c = true,
+            Disable_Flow_Flush_Batch__c = true
+        );
+
+        Test.startTest();
+        List<TritonFlow.FlowLogOutput> outputs = TritonFlow.log(
+            new List<TritonFlow.FlowLog>{ TritonTestFactory.makeFlowLog('nope') });
+        TritonTestFactory.flushCachedFlowLogs();
+        Test.stopTest();
+
+        System.assertEquals(1, outputs.size(), 'Output cardinality preserved');
+        TritonTestFactory.assertNoLogs();
+    }
 }

--- a/force-app/main/default/classes/TritonHelper.cls
+++ b/force-app/main/default/classes/TritonHelper.cls
@@ -24,6 +24,49 @@ public with sharing class TritonHelper {
 
     private static final String TRANSACTION_CACHE_KEY = 'tritonTransactionId';
     private static final Integer DEFAULT_TRANSACTION_CACHE_DURATION = 300;
+
+    // ─── Feature Switches ────────────────────────────────────────────
+
+    /**
+     * Cached org-level Triton settings, read once per transaction.
+     * @TestVisible so tests inject flag values without DML.
+     */
+    @TestVisible
+    private static TritonSettings__c settings {
+        get {
+            if (settings == null) {
+                settings = TritonSettings__c.getOrgDefaults();
+            }
+            return settings;
+        }
+        set;
+    }
+
+    /**
+     * True when all Triton logging is disabled via the org-level switch.
+     * Fail-safe: any error resolves to false (logging enabled) so a config
+     * read hiccup never silently drops logs.
+     */
+    public static Boolean isLoggingDisabled() {
+        try {
+            return settings != null && settings.Disable_Logging__c == true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * True when the deferred Flow flush batch is disabled. When disabled,
+     * Flow logs are flushed immediately instead of via the batch.
+     * Fail-safe: any error resolves to false (batch enabled).
+     */
+    public static Boolean isFlowFlushBatchDisabled() {
+        try {
+            return settings != null && settings.Disable_Flow_Flush_Batch__c == true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
     
     /**
      * Generates a user-specific cache key

--- a/force-app/main/default/classes/TritonHelper.cls
+++ b/force-app/main/default/classes/TritonHelper.cls
@@ -25,47 +25,22 @@ public with sharing class TritonHelper {
     private static final String TRANSACTION_CACHE_KEY = 'tritonTransactionId';
     private static final Integer DEFAULT_TRANSACTION_CACHE_DURATION = 300;
 
-    // ─── Feature Switches ────────────────────────────────────────────
+    // ─── Configuration ───────────────────────────────────────────────
 
     /**
-     * Cached org-level Triton settings, read once per transaction.
-     * @TestVisible so tests inject flag values without DML.
+     * Single entry point for all metadata-backed Triton configuration: the
+     * org-level feature switches (TritonSettings__c) and the log-level rules
+     * (Log_Level__mdt). Lazily initialized once per transaction. Tests mutate
+     * the instance's @TestVisible data rather than reading real org config.
      */
-    @TestVisible
-    private static TritonSettings__c settings {
+    public static TritonConfig Config {
         get {
-            if (settings == null) {
-                settings = TritonSettings__c.getOrgDefaults();
+            if (Config == null) {
+                Config = new TritonConfig();
             }
-            return settings;
+            return Config;
         }
-        set;
-    }
-
-    /**
-     * True when all Triton logging is disabled via the org-level switch.
-     * Fail-safe: any error resolves to false (logging enabled) so a config
-     * read hiccup never silently drops logs.
-     */
-    public static Boolean isLoggingDisabled() {
-        try {
-            return settings != null && settings.Disable_Logging__c == true;
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    /**
-     * True when the deferred Flow flush batch is disabled. When disabled,
-     * Flow logs are flushed immediately instead of via the batch.
-     * Fail-safe: any error resolves to false (batch enabled).
-     */
-    public static Boolean isFlowFlushBatchDisabled() {
-        try {
-            return settings != null && settings.Disable_Flow_Flush_Batch__c == true;
-        } catch (Exception e) {
-            return false;
-        }
+        private set;
     }
     
     /**
@@ -604,5 +579,187 @@ public with sharing class TritonHelper {
         }
 
         return parts.isEmpty() ? '' : String.join(parts, '\n');
+    }
+
+    // ─── Configuration types ─────────────────────────────────────────
+
+    /**
+     * Holds all metadata-backed Triton configuration and the policy that
+     * consumes it: the org-level feature switches (TritonSettings__c) and
+     * log-level filtering (Log_Level__mdt). Reached via TritonHelper.Config.
+     */
+    public class TritonConfig {
+
+        /**
+         * Cached org-level Triton settings, read once per transaction.
+         * @TestVisible so tests inject flag values without DML.
+         */
+        @TestVisible
+        TritonSettings__c settings {
+            get {
+                if (settings == null) {
+                    settings = TritonSettings__c.getOrgDefaults();
+                }
+                return settings;
+            }
+            set;
+        }
+
+        /**
+         * Raw Log_Level__mdt records. @TestVisible so tests supply their own.
+         */
+        @TestVisible
+        Log_Level__mdt[] logLevelsMdt = Log_Level__mdt.getAll().values();
+
+        /**
+         * Cached, parsed Log_Level__mdt rules used to decide whether a log is
+         * verbose enough to be persisted. Lazily built from logLevelsMdt and
+         * reset by tests by assigning null.
+         */
+        @TestVisible
+        List<LogLevelRule> logLevels {
+            get {
+                if (logLevels == null) {
+                    logLevels = new List<LogLevelRule>();
+                    for (Log_Level__mdt ll : logLevelsMdt) {
+                        logLevels.add(new LogLevelRule(ll));
+                    }
+                }
+                return logLevels;
+            }
+            set;
+        }
+
+        /**
+         * True when all Triton logging is disabled via the org-level switch.
+         * Fail-safe: any error resolves to false (logging enabled) so a config
+         * read hiccup never silently drops logs.
+         */
+        public Boolean isLoggingDisabled() {
+            try {
+                return settings != null && settings.Disable_Logging__c == true;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+
+        /**
+         * True when the deferred Flow flush batch is disabled. When disabled,
+         * Flow logs are flushed immediately instead of via the batch.
+         * Fail-safe: any error resolves to false (batch enabled).
+         */
+        public Boolean isFlowFlushBatchDisabled() {
+            try {
+                return settings != null && settings.Disable_Flow_Flush_Batch__c == true;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+
+        /**
+        * Checks if a log should be persisted based on the configured log levels.
+        *
+        * A Log_Level__mdt record "targets" a log when every attribute it specifies
+        * (Category, Type, Area, User Id, Component Name) matches the log. Unspecified
+        * (null) attributes act as wildcards, so a record can scope a level as broadly
+        * (a global default) or as narrowly (a single user or component) as needed.
+        *
+        * A log is allowed when either no configured level targets it, or at least one
+        * targeting level is verbose enough (its level is greater than or equal to the
+        * log's level).
+        * @param log -- Pharos log record to be saved
+        */
+        public Boolean isLogAllowed(pharos__Log__c log) {
+            if (String.isBlank(log.Log_Level__c) || logLevels.isEmpty()) return true;
+
+            String logUserId = normalizeUserId(log.pharos__User_Id__c);
+            String logComponent = getComponentName(log);
+            TritonTypes.Level currentLevel = TritonTypes.Level.valueOf(log.Log_Level__c);
+
+            Boolean anyLevelTargetsLog = false;
+            for (LogLevelRule rule : logLevels) {
+                if (!rule.targets(log, logUserId, logComponent)) continue;
+                anyLevelTargetsLog = true;
+                if (compareLevel(rule.level, currentLevel)) return true;
+            }
+
+            // No configured level targets this log -- allow it through by default.
+            return !anyLevelTargetsLog;
+        }
+    }
+
+    /**
+    * Resolves the component name used for log level matching.
+    * Flows are identified by their API name; Apex/LWC by the class/component
+    * portion of the Apex Name (the text before the first '.').
+    *
+    * Note: this runs during the log level check, before prepareForLogging derives
+    * the operation from the stack trace. The component is therefore only available
+    * when it is known at log() time -- LWC logs, Flow logs, or Apex logs with an
+    * explicit operation. Apex logs relying on stack-trace-derived naming will have
+    * a blank component here and are not matched by component-scoped levels.
+    * @param log -- Pharos log record being evaluated
+    * @return the component name, or null/blank when it cannot be determined
+    */
+    @TestVisible
+    private static String getComponentName(pharos__Log__c log) {
+        if (String.isNotBlank(log.pharos__Flow_API_Name__c)) return log.pharos__Flow_API_Name__c;
+
+        String apexName = log.pharos__Apex_Name__c;
+        if (String.isBlank(apexName)) return apexName;
+        Integer dotIndex = apexName.indexOf('.');
+        return dotIndex == -1 ? apexName : apexName.substring(0, dotIndex);
+    }
+
+    /**
+    * Salesforce Ids are 18 characters in Apex, but Log Level metadata stores the
+    * 15-character form. Matching is performed on the case-sensitive 15-character
+    * prefix so both representations line up.
+    * @param userId -- a 15 or 18 character user Id (or null)
+    * @return the 15-character prefix, or the original value when shorter/blank
+    */
+    @TestVisible
+    private static String normalizeUserId(String userId) {
+        return String.isNotBlank(userId) && userId.length() > 15 ? userId.substring(0, 15) : userId;
+    }
+
+    /**
+    * In-memory representation of a Log_Level__mdt record, parsed once and cached
+    * so that log level checks avoid re-reading and re-parsing metadata per log.
+    */
+    private class LogLevelRule {
+        private final String category;
+        private final String type;
+        private final String area;
+        private final String userId;
+        private final String component;
+        private final TritonTypes.Level level;
+
+        private LogLevelRule(Log_Level__mdt mdt) {
+            this.category = mdt.Category__c;
+            this.type = mdt.Type__c;
+            this.area = mdt.Area__c;
+            this.userId = normalizeUserId(mdt.User_Id__c);
+            this.component = mdt.Component_Name__c;
+            this.level = TritonTypes.Level.valueOf(mdt.Level__c);
+        }
+
+        /**
+        * True when every attribute specified on this rule matches the log.
+        * Null (unspecified) rule attributes are treated as wildcards.
+        */
+        private Boolean targets(pharos__Log__c log, String logUserId, String logComponent) {
+            return matches(category, log.pharos__Category__c)
+                && matches(type, log.pharos__Type__c)
+                && matches(area, log.pharos__Area__c)
+                && matches(userId, logUserId)
+                && matches(component, logComponent);
+        }
+
+        // String.equals is case-sensitive and null-safe, preserving the
+        // case-sensitivity required for 15-character Salesforce Ids.
+        private Boolean matches(String ruleValue, String logValue) {
+            return ruleValue == null || ruleValue.equals(logValue);
+        }
     }
 }

--- a/force-app/main/default/classes/TritonLwc.cls
+++ b/force-app/main/default/classes/TritonLwc.cls
@@ -31,7 +31,7 @@ global with sharing class TritonLwc {
     */
     @AuraEnabled
     public static void saveComponentLogs(List<ComponentLog> componentLogs) {
-        if (TritonHelper.isLoggingDisabled()) {
+        if (TritonHelper.Config.isLoggingDisabled()) {
             return;
         }
 

--- a/force-app/main/default/classes/TritonLwc.cls
+++ b/force-app/main/default/classes/TritonLwc.cls
@@ -31,6 +31,10 @@ global with sharing class TritonLwc {
     */
     @AuraEnabled
     public static void saveComponentLogs(List<ComponentLog> componentLogs) {
+        if (TritonHelper.isLoggingDisabled()) {
+            return;
+        }
+
         String transactionId = Triton.startTransaction();
         Triton.withCache();
         Boolean transactionIdFromCache = Triton.TRANSACTION_ID != transactionId;

--- a/force-app/main/default/classes/TritonTest.cls
+++ b/force-app/main/default/classes/TritonTest.cls
@@ -2432,4 +2432,62 @@ private class TritonTest {
             'Logging flag is independent and defaults false');
     }
 
+    @IsTest
+    private static void test_master_switch_disables_apex_logging() {
+        TritonTestFactory.assertNoLogs();
+        TritonHelper.settings = new TritonSettings__c(Disable_Logging__c = true);
+
+        Test.startTest();
+        Triton.logNow(Triton.t
+            .category(TritonTypes.Category.Apex)
+            .type(TritonTypes.Type.Backend)
+            .area(TritonTypes.Area.Accounts)
+            .summary('should not persist')
+            .level(TritonTypes.Level.INFO));
+        Triton.log(Triton.t
+            .category(TritonTypes.Category.Apex)
+            .summary('buffered should not persist')
+            .level(TritonTypes.Level.ERROR));
+        Triton.flush();
+        Test.stopTest();
+
+        TritonTestFactory.assertNoLogs();
+    }
+
+    @IsTest
+    private static void test_master_switch_enabled_still_logs() {
+        TritonTestFactory.assertNoLogs();
+        TritonHelper.settings = new TritonSettings__c(Disable_Logging__c = false);
+
+        Test.startTest();
+        Triton.logNow(Triton.t
+            .category(TritonTypes.Category.Apex)
+            .type(TritonTypes.Type.Backend)
+            .area(TritonTypes.Area.Accounts)
+            .summary('should persist')
+            .level(TritonTypes.Level.INFO));
+        Test.stopTest();
+
+        TritonTestFactory.assertLogCount(1);
+    }
+
+    @IsTest
+    private static void test_master_switch_disables_lwc_logging() {
+        TritonTestFactory.assertNoLogs();
+        TritonHelper.settings = new TritonSettings__c(Disable_Logging__c = true);
+
+        TritonLwc.ComponentLog cl = new TritonLwc.ComponentLog();
+        cl.category = TritonTypes.Category.LWC.name();
+        cl.level = TritonTypes.Level.INFO.name();
+        cl.summary = 'lwc should not persist';
+        cl.componentInfo = new TritonLwc.Component();
+        cl.componentInfo.name = 'myCmp';
+
+        Test.startTest();
+        TritonLwc.saveComponentLogs(new List<TritonLwc.ComponentLog>{ cl });
+        Test.stopTest();
+
+        TritonTestFactory.assertNoLogs();
+    }
+
 }

--- a/force-app/main/default/classes/TritonTest.cls
+++ b/force-app/main/default/classes/TritonTest.cls
@@ -33,10 +33,10 @@ private class TritonTest {
 
         Log_Level__mdt ll = new Log_Level__mdt();
         ll.Level__c = TritonTypes.Level.DEBUG.name();
-        Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{ll};
-        Triton.LOG_LEVELS = null;
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ll};
+        TritonHelper.Config.logLevels = null;
 
-        System.assertEquals(1, Triton.LOG_LEVELS.size(), 'Expected a single parsed log level rule');
+        System.assertEquals(1, TritonHelper.Config.logLevels.size(), 'Expected a single parsed log level rule');
     }
 
     @IsTest
@@ -45,7 +45,7 @@ private class TritonTest {
 
         Log_Level__mdt ll = new Log_Level__mdt();
         ll.Level__c = TritonTypes.Level.DEBUG.name();
-        Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{ll};
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ll};
 
         Test.startTest();
         Triton.logNow(Triton.t.category(TritonTypes.Category.Event).type(TritonTypes.Type.Backend).area(TritonTypes.Area.Community).summary('some event').details('error details').level(TritonTypes.Level.DEBUG));
@@ -60,7 +60,7 @@ private class TritonTest {
 
         Log_Level__mdt ll = new Log_Level__mdt();
         ll.Level__c = TritonTypes.Level.DEBUG.name();
-        Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{ll};
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ll};
 
         Test.startTest();
         Triton.logNow(Triton.t.category(TritonTypes.Category.Event).type(TritonTypes.Type.Backend).area(TritonTypes.Area.Community).summary('some event').details('error details').level(TritonTypes.Level.FINE));
@@ -82,8 +82,8 @@ private class TritonTest {
         categoryAndAreaLevel.Category__c = TritonTypes.Category.Event.name();
         categoryAndAreaLevel.Area__c = TritonTypes.Area.Community.name();
 
-        Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{globalLevel, categoryLevel, categoryAndAreaLevel};
-        Triton.LOG_LEVELS = null;
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{globalLevel, categoryLevel, categoryAndAreaLevel};
+        TritonHelper.Config.logLevels = null;
     }
 
     @IsTest
@@ -92,7 +92,7 @@ private class TritonTest {
 
         setupLogLevelsMap();
 
-        System.assertEquals(3, Triton.LOG_LEVELS.size(), 'Expected three parsed log level rules');
+        System.assertEquals(3, TritonHelper.Config.logLevels.size(), 'Expected three parsed log level rules');
 
         Test.startTest();
         Triton.logNow(Triton.t.category(TritonTypes.Category.Event).type(TritonTypes.Type.Backend).area(TritonTypes.Area.Community).summary('some event').details('error details').level(TritonTypes.Level.FINEST));
@@ -120,8 +120,8 @@ private class TritonTest {
         userLevel.Level__c = TritonTypes.Level.DEBUG.name();
         userLevel.User_Id__c = userId;
 
-        Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{ userLevel };
-        Triton.LOG_LEVELS = null;
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ userLevel };
+        TritonHelper.Config.logLevels = null;
     }
 
     @IsTest
@@ -179,8 +179,8 @@ private class TritonTest {
         Log_Level__mdt componentLevel = new Log_Level__mdt();
         componentLevel.Level__c = TritonTypes.Level.DEBUG.name();
         componentLevel.Component_Name__c = 'MyComponent';
-        Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{ componentLevel };
-        Triton.LOG_LEVELS = null;
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ componentLevel };
+        TritonHelper.Config.logLevels = null;
 
         Test.startTest();
         // Apex Name is Class.Method; the class portion must match the component name.
@@ -198,8 +198,8 @@ private class TritonTest {
         Log_Level__mdt componentLevel = new Log_Level__mdt();
         componentLevel.Level__c = TritonTypes.Level.DEBUG.name();
         componentLevel.Component_Name__c = 'MyComponent';
-        Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{ componentLevel };
-        Triton.LOG_LEVELS = null;
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ componentLevel };
+        TritonHelper.Config.logLevels = null;
 
         Test.startTest();
         // Component matches but FINE is more verbose than the allowed DEBUG.
@@ -219,8 +219,8 @@ private class TritonTest {
         Log_Level__mdt componentLevel = new Log_Level__mdt();
         componentLevel.Level__c = TritonTypes.Level.DEBUG.name();
         componentLevel.Component_Name__c = 'My_Flow';
-        Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{ componentLevel };
-        Triton.LOG_LEVELS = null;
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ componentLevel };
+        TritonHelper.Config.logLevels = null;
 
         Test.startTest();
         Triton.logNow(Triton.t.category(TritonTypes.Category.Event).type(TritonTypes.Type.Backend).area(TritonTypes.Area.Community)
@@ -243,8 +243,8 @@ private class TritonTest {
         allLevel.Area__c = TritonTypes.Area.Community.name();
         allLevel.User_Id__c = UserInfo.getUserId();
         allLevel.Component_Name__c = 'TestComponentName';
-        Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{ allLevel };
-        Triton.LOG_LEVELS = null;
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ allLevel };
+        TritonHelper.Config.logLevels = null;
 
         Test.startTest();
         // Matches every attribute at exactly the allowed level.
@@ -271,28 +271,28 @@ private class TritonTest {
     private static void test_get_component_name() {
         // Flow API name takes precedence.
         pharos__Log__c flowLog = new pharos__Log__c(pharos__Flow_API_Name__c = 'My_Flow', pharos__Apex_Name__c = 'Some.Apex');
-        System.assertEquals('My_Flow', Triton.getComponentName(flowLog));
+        System.assertEquals('My_Flow', TritonHelper.getComponentName(flowLog));
 
         // Apex name: class portion before the first dot.
         pharos__Log__c apexLog = new pharos__Log__c(pharos__Apex_Name__c = 'MyClass.myMethod');
-        System.assertEquals('MyClass', Triton.getComponentName(apexLog));
+        System.assertEquals('MyClass', TritonHelper.getComponentName(apexLog));
 
         // Apex name without a dot is returned as-is.
         pharos__Log__c plainLog = new pharos__Log__c(pharos__Apex_Name__c = 'MyClass');
-        System.assertEquals('MyClass', Triton.getComponentName(plainLog));
+        System.assertEquals('MyClass', TritonHelper.getComponentName(plainLog));
 
         // Nothing to resolve.
-        System.assertEquals(null, Triton.getComponentName(new pharos__Log__c()));
+        System.assertEquals(null, TritonHelper.getComponentName(new pharos__Log__c()));
     }
 
     @IsTest
     private static void test_normalize_user_id() {
         Id userId = UserInfo.getUserId();
-        System.assertEquals(String.valueOf(userId).substring(0, 15), Triton.normalizeUserId(userId),
+        System.assertEquals(String.valueOf(userId).substring(0, 15), TritonHelper.normalizeUserId(userId),
             '18-character Id should be truncated to its 15-character prefix');
-        System.assertEquals('015CHAR00000000', Triton.normalizeUserId('015CHAR00000000'),
+        System.assertEquals('015CHAR00000000', TritonHelper.normalizeUserId('015CHAR00000000'),
             '15-character value should be returned unchanged');
-        System.assertEquals(null, Triton.normalizeUserId(null));
+        System.assertEquals(null, TritonHelper.normalizeUserId(null));
     }
 
     @IsTest
@@ -2407,35 +2407,35 @@ private class TritonTest {
 
     @IsTest
     private static void test_switches_default_enabled() {
-        TritonHelper.settings = null;
-        System.assertEquals(false, TritonHelper.isLoggingDisabled(),
+        TritonHelper.Config.settings = null;
+        System.assertEquals(false, TritonHelper.Config.isLoggingDisabled(),
             'Logging should be enabled by default (org defaults / no record)');
-        System.assertEquals(false, TritonHelper.isFlowFlushBatchDisabled(),
+        System.assertEquals(false, TritonHelper.Config.isFlowFlushBatchDisabled(),
             'Flow flush batch should be enabled by default');
     }
 
     @IsTest
     private static void test_switch_logging_disabled_flag() {
-        TritonHelper.settings = new TritonSettings__c(Disable_Logging__c = true);
-        System.assertEquals(true, TritonHelper.isLoggingDisabled(),
+        TritonHelper.Config.settings = new TritonSettings__c(Disable_Logging__c = true);
+        System.assertEquals(true, TritonHelper.Config.isLoggingDisabled(),
             'isLoggingDisabled should reflect the Disable_Logging__c flag');
-        System.assertEquals(false, TritonHelper.isFlowFlushBatchDisabled(),
+        System.assertEquals(false, TritonHelper.Config.isFlowFlushBatchDisabled(),
             'Flow flush batch flag is independent and defaults false');
     }
 
     @IsTest
     private static void test_switch_flow_flush_batch_disabled_flag() {
-        TritonHelper.settings = new TritonSettings__c(Disable_Flow_Flush_Batch__c = true);
-        System.assertEquals(true, TritonHelper.isFlowFlushBatchDisabled(),
+        TritonHelper.Config.settings = new TritonSettings__c(Disable_Flow_Flush_Batch__c = true);
+        System.assertEquals(true, TritonHelper.Config.isFlowFlushBatchDisabled(),
             'isFlowFlushBatchDisabled should reflect the Disable_Flow_Flush_Batch__c flag');
-        System.assertEquals(false, TritonHelper.isLoggingDisabled(),
+        System.assertEquals(false, TritonHelper.Config.isLoggingDisabled(),
             'Logging flag is independent and defaults false');
     }
 
     @IsTest
     private static void test_master_switch_disables_apex_logging() {
         TritonTestFactory.assertNoLogs();
-        TritonHelper.settings = new TritonSettings__c(Disable_Logging__c = true);
+        TritonHelper.Config.settings = new TritonSettings__c(Disable_Logging__c = true);
 
         Test.startTest();
         Triton.logNow(Triton.t
@@ -2457,7 +2457,7 @@ private class TritonTest {
     @IsTest
     private static void test_master_switch_enabled_still_logs() {
         TritonTestFactory.assertNoLogs();
-        TritonHelper.settings = new TritonSettings__c(Disable_Logging__c = false);
+        TritonHelper.Config.settings = new TritonSettings__c(Disable_Logging__c = false);
 
         Test.startTest();
         Triton.logNow(Triton.t
@@ -2474,7 +2474,7 @@ private class TritonTest {
     @IsTest
     private static void test_master_switch_disables_lwc_logging() {
         TritonTestFactory.assertNoLogs();
-        TritonHelper.settings = new TritonSettings__c(Disable_Logging__c = true);
+        TritonHelper.Config.settings = new TritonSettings__c(Disable_Logging__c = true);
 
         TritonLwc.ComponentLog cl = new TritonLwc.ComponentLog();
         cl.category = TritonTypes.Category.LWC.name();

--- a/force-app/main/default/classes/TritonTest.cls
+++ b/force-app/main/default/classes/TritonTest.cls
@@ -2405,4 +2405,31 @@ private class TritonTest {
             'Cloned builder should preserve parent span ID');
     }
 
+    @IsTest
+    private static void test_switches_default_enabled() {
+        TritonHelper.settings = null;
+        System.assertEquals(false, TritonHelper.isLoggingDisabled(),
+            'Logging should be enabled by default (org defaults / no record)');
+        System.assertEquals(false, TritonHelper.isFlowFlushBatchDisabled(),
+            'Flow flush batch should be enabled by default');
+    }
+
+    @IsTest
+    private static void test_switch_logging_disabled_flag() {
+        TritonHelper.settings = new TritonSettings__c(Disable_Logging__c = true);
+        System.assertEquals(true, TritonHelper.isLoggingDisabled(),
+            'isLoggingDisabled should reflect the Disable_Logging__c flag');
+        System.assertEquals(false, TritonHelper.isFlowFlushBatchDisabled(),
+            'Flow flush batch flag is independent and defaults false');
+    }
+
+    @IsTest
+    private static void test_switch_flow_flush_batch_disabled_flag() {
+        TritonHelper.settings = new TritonSettings__c(Disable_Flow_Flush_Batch__c = true);
+        System.assertEquals(true, TritonHelper.isFlowFlushBatchDisabled(),
+            'isFlowFlushBatchDisabled should reflect the Disable_Flow_Flush_Batch__c flag');
+        System.assertEquals(false, TritonHelper.isLoggingDisabled(),
+            'Logging flag is independent and defaults false');
+    }
+
 }

--- a/force-app/main/default/classes/TritonTestFactory.cls
+++ b/force-app/main/default/classes/TritonTestFactory.cls
@@ -24,8 +24,8 @@ public class TritonTestFactory {
      */
     public static void initTestSetup() {
         pharos.Test_Logger.initSettings();
-        Triton.LOG_LEVELS_MDT = new Log_Level__mdt[]{};
-        Triton.LOG_LEVELS = null;
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{};
+        TritonHelper.Config.logLevels = null;
     }
 
     // ─── State Reset ────────────────────────────────────────────────

--- a/force-app/main/default/objects/TritonSettings__c/TritonSettings__c.object-meta.xml
+++ b/force-app/main/default/objects/TritonSettings__c/TritonSettings__c.object-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customSettingsType>Hierarchy</customSettingsType>
+    <description>Global runtime switches for the Triton logging framework. Managed at the org (default) level.</description>
+    <label>Triton Settings</label>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/TritonSettings__c/fields/Disable_Flow_Flush_Batch__c.field-meta.xml
+++ b/force-app/main/default/objects/TritonSettings__c/fields/Disable_Flow_Flush_Batch__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Disable_Flow_Flush_Batch__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>When checked, Flow logs are flushed immediately (synchronously, in-transaction) instead of via the delayed TritonFlowFlushBatch. No logs are lost.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>When checked, Flow logs flush immediately instead of using the delayed batch.</inlineHelpText>
+    <label>Disable Flow Flush Batch</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/TritonSettings__c/fields/Disable_Logging__c.field-meta.xml
+++ b/force-app/main/default/objects/TritonSettings__c/fields/Disable_Logging__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Disable_Logging__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>When checked, all Triton logging (Apex, Flow, LWC) is disabled. Logs are short-circuited before they are built or persisted.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Master kill switch. When checked, Triton creates and persists no logs.</inlineHelpText>
+    <label>Disable Logging</label>
+    <type>Checkbox</type>
+</CustomField>


### PR DESCRIPTION
## Summary

Adds two **global** runtime switches to the Pharos Triton logging framework, backed by a new org-level Hierarchy Custom Setting `TritonSettings__c` (both default off = current behavior preserved):

- **`Disable_Logging__c`** — master kill switch. Gated at the earliest point of each server-side entry (`Triton.log` before any `builder.build()`, `TritonFlow.log` before the build loop, `TritonLwc.saveComponentLogs` before its work), so disabled logging incurs essentially no persistence overhead (no DML / platform events). `TritonFlow.log` still returns one `FlowLogOutput` per input to preserve the invocable contract.
- **`Disable_Flow_Flush_Batch__c`** — when set, Flow logs are flushed immediately/synchronously via `Triton.flush()` instead of the deferred ~1-min `TritonFlowFlushBatch`. No logs lost; no Org Cache write, no scheduled batch.

Flags are read only through helpers `TritonHelper.isLoggingDisabled()` / `isFlowFlushBatchDisabled()` (single source of truth), which fail **safe**: any read error resolves to *enabled* so logs are never silently dropped. When both flags are on, the logging switch wins.

## Changes
- New `TritonSettings__c` Hierarchy Custom Setting + two checkbox fields.
- `TritonHelper`: lazy `@TestVisible` settings accessor + two helper methods.
- Gates in `Triton.cls`, `TritonFlow.cls`, `TritonLwc.cls`.
- Immediate-flush path in `TritonFlow.cls` when the batch is disabled.
- Apex tests across all channels + combined-flags interaction test.

## Test plan
- [x] Full Apex suite (`TritonTest` + `TritonFlowTest`) green: **119/119** on the target org.
- [x] Master switch off: Apex / Flow / LWC persist nothing (verified by SOQL count after `Test.stopTest()`).
- [x] Master switch on (default/false): behavior unchanged.
- [x] Flow batch disabled: no Org Cache write, no batch job, log persisted immediately.
- [x] Flow batch enabled: logs buffered in Org Cache for deferred flush (unchanged).
- [x] Both flags on: one output per input, no logs persisted.

## Notes
- Backward compatible: no setting record ⇒ both features enabled (identical to today).
- When logging is disabled, `TritonFlow.log` returns `null` stacktrace output variables (acceptable for a kill switch).