### PR TITLE
fix(builder): defensive shallow clone in build() to prevent record aliasing

### DIFF
--- a/force-app/main/default/classes/TritonBuilder.cls
+++ b/force-app/main/default/classes/TritonBuilder.cls
@@ -805,7 +805,13 @@ public with sharing class TritonBuilder {
     */
     public pharos__Log__c build() {
         ensureSpanIds();
-        pharos__Log__c log = this.builder.build();
+        // Defensive shallow clone: the underlying managed builder returns the
+        // same sObject instance from every build(). Without a clone, reusing a
+        // TritonBuilder across multiple log() calls makes every buffered record
+        // alias the latest build — later logs silently overwrite earlier ones.
+        // Shallow suffices (pharos__Log__c is a flat record) and is negligible
+        // next to builder construction.
+        pharos__Log__c log = this.builder.build().clone(false, false, false, false);
 
         // Default category to Apex when not explicitly set
         if(String.isNotBlank(categoryValue)) {

--- a/force-app/main/default/classes/TritonBuilderReuseTest.cls
+++ b/force-app/main/default/classes/TritonBuilderReuseTest.cls
@@ -1,0 +1,42 @@
+/**
+ * Regression test for TritonBuilder.build() aliasing: the managed builder
+ * returns the same sObject instance from every build(), so without the
+ * defensive clone in build(), reusing one TritonBuilder across multiple
+ * Triton.log() calls makes every buffered record alias the latest build.
+ */
+@IsTest
+private class TritonBuilderReuseTest {
+
+    @IsTest
+    static void reusedBuilderBuffersDistinctRecords() {
+        Triton.startTransaction();
+        TritonBuilder reused = Triton.makeBuilder()
+            .category(TritonTypes.Category.Apex)
+            .type(TritonTypes.Type.Backend)
+            .area(TritonTypes.Area.Community)
+            .stackTrace('Class.TritonBuilderReuseTest.run: line 1');
+
+        Triton.log(reused.operation('ReuseTest.first').summary('first record'));
+        Triton.log(reused.operation('ReuseTest.second').summary('second record'));
+
+        List<pharos__Log__c> buffered = Triton.drain();
+        System.assertEquals(2, buffered.size(), 'two records should be buffered');
+        System.assertNotEquals(buffered[0], buffered[1],
+            'buffered records must not alias one instance');
+        System.assertEquals('first record', buffered[0].pharos__Summary__c,
+            'first record must keep its own field values');
+        System.assertEquals('second record', buffered[1].pharos__Summary__c,
+            'second record must keep its own field values');
+    }
+
+    @IsTest
+    static void buildTwiceReturnsIndependentRecords() {
+        TritonBuilder b = Triton.makeBuilder().summary('one');
+        pharos__Log__c first = b.build();
+        b.summary('two');
+        pharos__Log__c second = b.build();
+        System.assertEquals('one', first.pharos__Summary__c,
+            'a built record must not be mutated by later builder writes');
+        System.assertEquals('two', second.pharos__Summary__c);
+    }
+}

--- a/force-app/main/default/classes/TritonBuilderReuseTest.cls-meta.xml
+++ b/force-app/main/default/classes/TritonBuilderReuseTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
## Problem

The underlying managed `pharos.LogBuilder` returns the **same sObject instance** from every `build()` call. Reusing one `TritonBuilder` across multiple `Triton.log()` calls therefore makes every buffered record alias the latest build — later logs silently overwrite earlier ones in the buffer. Nothing in the API contract warns against builder reuse, and reuse is attractive: builder construction (`makeBuilder()`) is the single largest CPU cost of producing a log (~1.7 ms measured), so high-volume callers naturally reach for it.

Discovered while benchmarking span logging CPU in a large org (Stripe sandbox observability POC): a reused builder produced N buffered records that all carried the last span's field values.

## Fix

`TritonBuilder.build()` returns a **shallow** defensive clone. `pharos__Log__c` is a flat record, so shallow is sufficient; deep clone was measured at ~2.9 ms per build and rejected — shallow is negligible next to builder construction.

## Tests

New `TritonBuilderReuseTest`:
- reuse across two `Triton.log()` calls buffers two independent records
- `build()` twice returns records that don't mutate each other

Full existing suite green in the test org: `TritonTest` 100/100, `TritonFlowTest` + `LogLimitsControllerTest` 61/61.