### PR TITLE
Fix/stable parent for open marks

### DIFF
--- a/force-app/main/default/lwc/triton/__tests__/triton.test.js
+++ b/force-app/main/default/lwc/triton/__tests__/triton.test.js
@@ -830,6 +830,33 @@ describe('SpanContext', () => {
     expect(parent).toBe('stable-parent');
   });
 
+  test('log parents skip the span id of a mark that is still open', () => {
+    // startMark() pushes its span id onto the stack but only publishes the
+    // record in endMark(). Parenting a log on that id points it at a span that
+    // has not been emitted — and never will be if the mark does not close.
+    const bound = triton.bindToComponent('c-test');
+    triton.spanContext.reset('root');
+    triton.spanContext.push('closed-work-span');
+    bound.startPerformanceMark('slow-thing');
+
+    const openMarkSpanId = triton.spanContext.current();
+    expect(triton.performance.isActiveMarkSpanId(openMarkSpanId)).toBe(true);
+
+    const builder = triton.refreshBuilder(new TritonBuilder());
+
+    expect(builder.parentSpanId).toHaveBeenCalledWith('closed-work-span');
+    expect(builder.parentSpanId).not.toHaveBeenCalledWith(openMarkSpanId);
+  });
+
+  test('log parents use the stack top when no mark is open', () => {
+    triton.spanContext.reset('root');
+    triton.spanContext.push('closed-work-span');
+
+    const builder = triton.refreshBuilder(new TritonBuilder());
+
+    expect(builder.parentSpanId).toHaveBeenCalledWith('closed-work-span');
+  });
+
   test('enableSpanPersistence should enable sessionStorage', () => {
     triton.enableSpanPersistence();
     triton.spanContext.push('persisted-span');

--- a/force-app/main/default/lwc/triton/triton.js
+++ b/force-app/main/default/lwc/triton/triton.js
@@ -279,20 +279,10 @@ export default class Triton {
     }
 
     /**
-     * Resolves the parent span id for a new log, skipping the span ids of marks
-     * that are still open.
-     *
-     * startMark() pushes its span id onto the context stack immediately but only
-     * publishes the record in endMark(). Taking the stack top as-is therefore
-     * points every log built meanwhile at a span that has not been emitted — and
-     * if the mark never closes (component unmounted, navigation, an exception
-     * between start and end) it never will be, leaving those logs parented to
-     * nothing. Measured on a live E-Bikes purchase: 60 LWC spans referencing
-     * three span ids that were absent from the trace, 30 of them under one.
-     *
-     * Skipping open marks nests such logs one level higher instead — under the
-     * mark's own parent. Flatter than intended, but a real ancestor rather than
-     * a dangling reference.
+     * Resolves the parent span id for a new log, skipping marks that are still
+     * open: startMark() pushes a span id but endMark() publishes the record, so
+     * the stack top can name a span that has not been emitted yet — or never
+     * will be, if the mark does not close.
      * @private
      * @returns {string|null}
      */

--- a/force-app/main/default/lwc/triton/triton.js
+++ b/force-app/main/default/lwc/triton/triton.js
@@ -275,7 +275,34 @@ export default class Triton {
             .transactionId(this.transactionId)
             .timestamp(Date.now())
             .spanId(generateTransactionId())
-            .parentSpanId(this.spanContext.current());
+            .parentSpanId(this.stableParentSpanId());
+    }
+
+    /**
+     * Resolves the parent span id for a new log, skipping the span ids of marks
+     * that are still open.
+     *
+     * startMark() pushes its span id onto the context stack immediately but only
+     * publishes the record in endMark(). Taking the stack top as-is therefore
+     * points every log built meanwhile at a span that has not been emitted — and
+     * if the mark never closes (component unmounted, navigation, an exception
+     * between start and end) it never will be, leaving those logs parented to
+     * nothing. Measured on a live E-Bikes purchase: 60 LWC spans referencing
+     * three span ids that were absent from the trace, 30 of them under one.
+     *
+     * Skipping open marks nests such logs one level higher instead — under the
+     * mark's own parent. Flatter than intended, but a real ancestor rather than
+     * a dangling reference.
+     * @private
+     * @returns {string|null}
+     */
+    stableParentSpanId() {
+        if (!this.performance || typeof this.performance.isActiveMarkSpanId !== 'function') {
+            return this.spanContext.current();
+        }
+        return this.spanContext.getStableParent(
+            (spanId) => this.performance.isActiveMarkSpanId(spanId)
+        );
     }
 
     /**


### PR DESCRIPTION
## Problem

`PerformanceTracker.startMark()` pushes its span id onto the context stack immediately, but the record itself is only published by `endMark()`:

```js
const spanId = generateTransactionId();
const parentSpanId = tritonInstance.spanContext.current();
tritonInstance.spanContext.push(spanId);   // on the stack
componentData.marks.set(markName, {...});  // nothing logged yet
```

Every log built while that mark is open takes the stack top as its parent — `refreshBuilder()` reads `spanContext.current()` directly — so it points at a span that has not been emitted. If the mark never closes (component unmounted, navigation away, an exception between start and end), that span is never emitted at all and the logs stay parented to nothing.

## Evidence

Measured on a live E-Bikes purchase trace (org `00DWI`, exported from Tempo):

- **119 of 271 spans referenced a parent absent from the trace** — 25 distinct phantom ids.
- **60 of those were LWC spans**, clustered under three ids: 30 / 12 / 12 children. All from different components (`productTile`, `orderBuilder`, `ebikesCartSummary`, `ebikesShopCart`, `paginator`), none carrying a transaction or request id — the signature of an open mark.
- The trace was otherwise well-formed: single root, correct `session → transaction → request → work` nesting.

Backends render such spans as detached fragments or drop them from the waterfall entirely.

The remaining orphans in that trace (42 Flow, 17 Apex) have a different shape — they *do* carry a transaction id — and are **not** addressed here. Their cause is still open.

## Fix

The guard for this already existed and was never wired up:

- `SpanContext.getStableParent(isActiveMarkFn)` — "walks the stack from top down, skipping any span IDs that match active marks"
- `PerformanceTracker.isActiveMarkSpanId(spanId)` — exactly the predicate it wants

Both had unit tests; neither was called from production code. `refreshBuilder()` now resolves the parent through them, via a small `stableParentSpanId()` helper that falls back to the previous behaviour when no `PerformanceTracker` is attached.

## Trade-off

Logs written while a mark is open now nest **one level higher** — under the mark's own parent instead of under the mark. The hierarchy is flatter than intended, but every parent reference resolves to a span that exists. That seemed clearly preferable to a dangling reference; happy to revisit if you'd rather the mark span were emitted eagerly at `startMark()` instead.

## Tests

Two added to `triton.test.js`:

- a log built while a mark is open is parented to the span *below* the mark, not to the mark itself
- with no mark open, the stack top is used as before

Verified the first one is not vacuous: restoring `spanContext.current()` in `refreshBuilder` makes it fail, the fix makes it pass. Full suite: **135 passed**.


## Follow-up: keeping the hierarchy intact

This PR removes the dangling references but flattens one level. A fuller fix is possible, and `timeBackendCall` already shows the shape: it publishes **two** records under one span id — `Backend call started: X` when the call begins and `Backend call completed: X` with the duration when it ends — and Iris collapses the pair into a single span.

Doing the same for marks (`startMark()` publishing its own record, `endMark()` the completion) would mean the mark's span exists from the moment it opens, so children nest under it properly and no level is lost. An unclosed mark stops being a problem too: Iris emits an in-progress span from the "started" record alone.

That change cannot land here, because Iris recognises a "started" record by an exact prefix:

```go
strings.HasPrefix(l.Summary, "Backend call started:") ||
strings.HasPrefix(l.Summary, "User interaction started:")
```

`endMark` writes `Performance: <component> - <name>`, which matches neither — so a paired record would arrive as a *second span with the same span id* rather than being collapsed. It needs the Iris side taught first, then Triton, in that order.

Filed as a separate change so this one stays small and safe to merge on its own.
