### PR TITLE
Publish a performance mark's opening record when it starts

### DIFF
--- a/force-app/main/default/lwc/triton/__tests__/triton.test.js
+++ b/force-app/main/default/lwc/triton/__tests__/triton.test.js
@@ -635,10 +635,38 @@ describe('PerformanceTracker', () => {
     const initialLogCount = triton.logs.length;
     
     boundTriton.startPerformanceMark(markName);
+    // The opening record ships immediately, so the span exists while the mark
+    // is open and logs written meanwhile have a real parent to nest under.
+    expect(triton.logs.length).toBe(initialLogCount + 1);
+
     boundTriton.endPerformanceMark(markName);
     
-    // Should create a performance log
-    expect(triton.logs.length).toBe(initialLogCount + 1);
+    // Two records, one span: the backend pairs them by span id, the same way it
+    // pairs "Backend call started/completed".
+    expect(triton.logs.length).toBe(initialLogCount + 2);
+    const [opening, completion] = triton.logs.slice(-2);
+    expect(opening.summary).toHaveBeenCalledWith(
+      expect.stringContaining('Performance started:')
+    );
+    expect(opening.spanId.mock.calls[0][0]).toBe(completion.spanId.mock.calls[0][0]);
+    expect(completion.duration).toHaveBeenCalled();
+  });
+
+  test('an open mark is already a real span for logs written under it', () => {
+    // Before the opening record existed, a log written while the mark was open
+    // named a span that had not been emitted — and never would be if the mark
+    // stayed open. Measured on a live purchase trace: 60 LWC spans pointing at
+    // three span ids that were absent from it, 30 under a single one.
+    const initialLogCount = triton.logs.length;
+
+    boundTriton.startPerformanceMark('slow-thing');
+    const openMarkSpanId = triton.spanContext.current();
+
+    boundTriton.log(boundTriton.info(TYPE.FRONTEND, AREA.OTHER).summary('work'));
+
+    const [opening, work] = triton.logs.slice(initialLogCount);
+    expect(opening.spanId).toHaveBeenCalledWith(openMarkSpanId);
+    expect(work.parentSpanId).toHaveBeenCalledWith(openMarkSpanId);
   });
 
   test('should warn when ending non-existent mark', () => {
@@ -699,7 +727,8 @@ describe('PerformanceTracker', () => {
     boundTriton.endPerformanceMark('mark1');
     boundTriton2.endPerformanceMark('mark2');
     
-    expect(triton.logs.length).toBe(initialLogCount + 2);
+    // Two marks, each an opening record plus a completion.
+    expect(triton.logs.length).toBe(initialLogCount + 4);
   });
 
   test('should create component data for unknown components', () => {

--- a/force-app/main/default/lwc/triton/triton.js
+++ b/force-app/main/default/lwc/triton/triton.js
@@ -631,6 +631,22 @@ class PerformanceTracker {
             parentSpanId: parentSpanId
         });
 
+        // Publish the opening record straight away, under the same span id the
+        // completion will carry. Without it the span only appears when endMark()
+        // runs, so every log written meanwhile is parented to a span that does
+        // not exist yet — and never will, if the mark is left open by an
+        // unmounted component, a navigation or an exception. The backend pairs
+        // the two by span id and collapses them into one span, the way it
+        // already does for "Backend call started/completed".
+        tritonInstance.log(
+            tritonInstance.makeBuilder()
+                .type(TYPE.PERFORMANCE)
+                .summary(`Performance started: ${tritonInstance._componentId || 'unknown'} - ${markName}`)
+                .action(markName)
+                .spanId(spanId)
+                .parentSpanId(parentSpanId)
+        );
+
         return markName;
     }
 


### PR DESCRIPTION
## Problem

A performance mark publishes nothing until it closes. `startMark()` pushes its span id onto the context stack, but the record is only written by `endMark()`:

```js
const spanId = generateTransactionId();
tritonInstance.spanContext.push(spanId);   // on the stack
componentData.marks.set(markName, {...});  // nothing logged
```

So every log built while the mark is open is parented to a span that has not been emitted. If the mark never closes — component unmounted, navigation away, an exception between start and end — it never will be, and those logs stay parented to nothing.

Measured on a live E-Bikes purchase trace: **60 LWC spans referenced three span ids absent from the trace, 30 of them under a single one**. Backends render such spans as detached fragments or drop them from the waterfall.

## Fix

`startMark()` now publishes an opening record under the same span id the completion will carry:

```
Performance started: <component> - <mark>     (no duration)
Performance: <component> - <mark>             (with duration)
```

This mirrors `timeBackendCall`, which has always emitted `Backend call started: X` / `Backend call completed: X` under one span id. The backend pairs the two records by span id and collapses them into a single span.

Two consequences, both good:

- **The hierarchy stays intact.** Children nest under the mark itself — no level is lost, unlike skipping open marks when resolving the parent.
- **An unclosed mark degrades gracefully.** The backend emits it as an in-progress span from the opening record alone, instead of orphaning everything written under it.

## Rollout order

The backend recognises an opening record by prefix. `Performance started:` was added there first (Hermes `06e1ad4`); an unrecognised prefix is treated as a plain log, so a paired record arriving at an older backend would produce **two spans sharing a span id** rather than one.

That side is already deployed, so this can merge whenever. Nothing breaks if it merges first either — the pairing simply does not collapse until the backend catches up.

## Tests

- the two existing mark tests asserted one record per mark; they now assert the pair and check both halves share a span id
- new: a log written while a mark is open resolves to a parent that exists

Verified the new test is not vacuous — removing the opening record makes it fail. Full suite: **134 passed**.


