### PR TITLE
LOG-2921: Fix Log Level rule evaluation — wildcard, fail-safe, user, matching, flow version

### DIFF
--- a/agent-skills/instrument-flows.md
+++ b/agent-skills/instrument-flows.md
@@ -132,7 +132,7 @@ Each logging point is a single `<actionCalls>` element referencing the `TritonFl
 
 Every log action must include the three required inputs (`area`, `summary`, `interviewGUID`). The sections below list the additional per-location inputs.
 
-Pass the plain API name in `flowApiName` and the version separately in `flowVersion` (omit it when unknown). Version-suffixed names like `My_Flow-4` are a legacy artifact — the log-level engine tolerates them, but new instrumentation must not emit them.
+Pass the plain API name in `flowApiName` and the version separately in `flowVersion` (omit it when unknown). Never emit version-suffixed names like `My_Flow-4` — they will not match component-scoped log levels.
 
 ### 3a — Flow entry logging
 

--- a/agent-skills/instrument-flows.md
+++ b/agent-skills/instrument-flows.md
@@ -78,7 +78,8 @@ Each logging point is a single `<actionCalls>` element referencing the `TritonFl
 | `level` | no | `INFO`/`DEBUG`/`WARNING`/`ERROR` string; defaults to `INFO` |
 | `details` | no | Additional context |
 | `operation` | no | Operation name |
-| `flowApiName` | no | The flow API name |
+| `flowApiName` | no | The **plain** flow API name — never append a `-<version>` suffix |
+| `flowVersion` | no | Numeric flow version as a string (e.g. `4`); pairs with the plain `flowApiName`, matching native flow error logs |
 | `transactionId` | no | Stitch into an existing transaction (Step 3f) |
 | `additionalFields` | no | JSON string → arbitrary `pharos__Log__c` fields |
 | `stacktrace` / `fullStacktrace` | no | Carry-through inputs for chaining fault context |
@@ -119,6 +120,10 @@ Each logging point is a single `<actionCalls>` element referencing the `TritonFl
         <value><stringValue><FlowApiName></stringValue></value>
     </inputParameters>
     <inputParameters>
+        <name>flowVersion</name>
+        <value><stringValue><FlowVersionNumber></stringValue></value>
+    </inputParameters>
+    <inputParameters>
         <name>level</name>
         <value><stringValue>INFO</stringValue></value>
     </inputParameters>
@@ -126,6 +131,8 @@ Each logging point is a single `<actionCalls>` element referencing the `TritonFl
 ```
 
 Every log action must include the three required inputs (`area`, `summary`, `interviewGUID`). The sections below list the additional per-location inputs.
+
+Pass the plain API name in `flowApiName` and the version separately in `flowVersion` (omit it when unknown). Version-suffixed names like `My_Flow-4` are a legacy artifact — the log-level engine tolerates them, but new instrumentation must not emit them.
 
 ### 3a — Flow entry logging
 

--- a/force-app/main/default/classes/TritonBuilder.cls
+++ b/force-app/main/default/classes/TritonBuilder.cls
@@ -28,6 +28,7 @@ public with sharing class TritonBuilder {
     public static final String STACKTRACE_PARSE_RESULT = 'pharos__Stacktrace_Parse_Result__c';
     public static final String USER_ID = 'pharos__User_Id__c';
     public static final String FLOW_API_NAME = 'pharos__Flow_API_Name__c';
+    public static final String FLOW_VERSION = 'pharos__Flow_Version__c';
     public static final String DO_NOT_CREATE_ISSUE = 'pharos__Do_Not_Create_Issue__c';
     public static final String REQUEST_ID = 'pharos__Request_Id_External__c';
     public static final String SPAN_ID = 'Span_Id__c';
@@ -137,6 +138,14 @@ public with sharing class TritonBuilder {
     public TritonBuilder() {
         this.builder = pharos.LogBuilder.getInstance();
         initBuilder();
+        // Emission-time user stamping (LOG-2921): the log must carry its user when
+        // isLogAllowed runs, not only after pharos.Logger.flushInternal fills the
+        // field at flush time (fill-when-null, so this value survives untouched).
+        // An explicit .userId(...) call overrides by re-setting the attribute.
+        // Deliberately NOT in initBuilder(): cloneBuilder() re-runs initBuilder()
+        // after copying the source's fields, and a stamp there would clobber an
+        // explicitly-set user id.
+        this.builder.attribute(USER_ID, UserInfo.getUserId());
     }
 
     private void initBuilder() {
@@ -507,6 +516,20 @@ public with sharing class TritonBuilder {
     */
     public TritonBuilder flowApiName(String apiName) {
         this.builder.attribute(FLOW_API_NAME, apiName);
+        return this;
+    }
+
+    /**
+    * Set flow version for the log. Native flow error logs store the plain flow
+    * API name with the version in this separate field; instrumented flow logs
+    * follow the same convention (LOG-2921). The managed field is Text, so the
+    * numeric version is stored in its canonical string form -- the same shape
+    * the managed package's own flow error parsing writes.
+    * @param version -- flow version number
+    * @return this builder instance
+    */
+    public TritonBuilder flowVersion(Decimal version) {
+        this.builder.attribute(FLOW_VERSION, version == null ? null : String.valueOf(version));
         return this;
     }
 

--- a/force-app/main/default/classes/TritonBuilder.cls
+++ b/force-app/main/default/classes/TritonBuilder.cls
@@ -138,14 +138,6 @@ public with sharing class TritonBuilder {
     public TritonBuilder() {
         this.builder = pharos.LogBuilder.getInstance();
         initBuilder();
-        // Emission-time user stamping (LOG-2921): the log must carry its user when
-        // isLogAllowed runs, not only after pharos.Logger.flushInternal fills the
-        // field at flush time (fill-when-null, so this value survives untouched).
-        // An explicit .userId(...) call overrides by re-setting the attribute.
-        // Deliberately NOT in initBuilder(): cloneBuilder() re-runs initBuilder()
-        // after copying the source's fields, and a stamp there would clobber an
-        // explicitly-set user id.
-        this.builder.attribute(USER_ID, UserInfo.getUserId());
     }
 
     private void initBuilder() {
@@ -520,11 +512,9 @@ public with sharing class TritonBuilder {
     }
 
     /**
-    * Set flow version for the log. Native flow error logs store the plain flow
-    * API name with the version in this separate field; instrumented flow logs
-    * follow the same convention (LOG-2921). The managed field is Text, so the
-    * numeric version is stored in its canonical string form -- the same shape
-    * the managed package's own flow error parsing writes.
+    * Set flow version for the log, following the native flow error log convention
+    * (plain API name + separate version). The managed field is Text, so the
+    * numeric version is stored in its canonical string form.
     * @param version -- flow version number
     * @return this builder instance
     */
@@ -835,6 +825,12 @@ public with sharing class TritonBuilder {
             log.pharos__Category__c = categoryValue;
         } else if(String.isBlank(log.pharos__Category__c)) {
             log.pharos__Category__c = TritonTypes.Category.Apex.name();
+        }
+
+        // Default to the running user when not explicitly set, so user-scoped
+        // log level rules can match at filter time (before the flush-time fill)
+        if(String.isBlank(log.pharos__User_Id__c)) {
+            log.pharos__User_Id__c = UserInfo.getUserId();
         }
 
         // Auto-carryover: if summary was truncated, append full text to details

--- a/force-app/main/default/classes/TritonFlow.cls
+++ b/force-app/main/default/classes/TritonFlow.cls
@@ -23,6 +23,7 @@
 global with sharing class TritonFlow {
     private static final String INVALID_LOG_LEVEL = 'Unable to locate log level: {0}. Default INFO level will be used.';
     private static final String INVALID_CATEGORY = 'Unable to locate category: {0}. Default Flow category will be used.';
+    private static final String INVALID_FLOW_VERSION = 'Unable to parse flow version: {0}. Flow Version will not be set.';
     
     /**
      * @description
@@ -92,6 +93,15 @@ global with sharing class TritonFlow {
             }
         }
         
+        Decimal flowVersion;
+        if (String.isNotBlank(flowLog.flowVersion)) {
+            try {
+                flowVersion = Decimal.valueOf(flowLog.flowVersion.trim());
+            } catch (Exception e) {
+                flowDetails += Triton.SPACE_SEP + TritonHelper.formatMessage(INVALID_FLOW_VERSION, flowLog.flowVersion);
+            }
+        }
+
         //resume or start transaction if one isn't already in progress
         if(String.isNotBlank(flowLog.transactionId)) {
             Triton.resumeTransaction(flowLog.transactionId);
@@ -118,6 +128,10 @@ global with sharing class TritonFlow {
                                     .pendingJobs(true)
                                     .totalActiveSession(true))
                 .level(level);
+
+        if (flowVersion != null) {
+            builder.flowVersion(flowVersion);
+        }
 
         // if the log level is ERROR, create an issue
         if(level == TritonTypes.Level.ERROR) {
@@ -162,6 +176,8 @@ global with sharing class TritonFlow {
         global String interviewGUID;
         @InvocableVariable(Required=false Label='Flow API Name')
         global String flowApiName;
+        @InvocableVariable(Required=false Label='Flow Version')
+        global String flowVersion;
         @InvocableVariable(Required=false Label='Level')
         global String level;
         @InvocableVariable(Required=false Label='Transaction ID')

--- a/force-app/main/default/classes/TritonFlowTest.cls
+++ b/force-app/main/default/classes/TritonFlowTest.cls
@@ -86,8 +86,8 @@ private class TritonFlowTest {
     }
 
     /**
-     * LOG-2921: a user-scoped rule must target flow logs — the builder stamps the
-     * running user at emission time, before isLogAllowed runs.
+     * A user-scoped rule targets flow logs: the user is defaulted at build time,
+     * before isLogAllowed runs.
      */
     @IsTest
     private static void test_flow_log_carries_running_user_at_filter_time() {
@@ -112,8 +112,7 @@ private class TritonFlowTest {
     }
 
     /**
-     * LOG-2921: the optional flowVersion input maps to pharos__Flow_Version__c,
-     * matching the plain-name + separate-version convention of native flow logs.
+     * The optional flowVersion input maps to pharos__Flow_Version__c.
      */
     @IsTest
     private static void test_flow_version_passthrough() {
@@ -143,8 +142,8 @@ private class TritonFlowTest {
     }
 
     /**
-     * LOG-2921: an unparsable flowVersion leaves the field null and appends a
-     * note to details, mirroring the invalid-level handling.
+     * An unparsable flowVersion leaves the field null and appends a note to
+     * details, mirroring the invalid-level handling.
      */
     @IsTest
     private static void test_flow_version_unparsable_noted_in_details() {

--- a/force-app/main/default/classes/TritonFlowTest.cls
+++ b/force-app/main/default/classes/TritonFlowTest.cls
@@ -86,6 +86,88 @@ private class TritonFlowTest {
     }
 
     /**
+     * LOG-2921: a user-scoped rule must target flow logs — the builder stamps the
+     * running user at emission time, before isLogAllowed runs.
+     */
+    @IsTest
+    private static void test_flow_log_carries_running_user_at_filter_time() {
+        TritonTestFactory.assertNoLogs();
+        TritonTestFactory.resetFlowState();
+
+        Log_Level__mdt userLevel = new Log_Level__mdt();
+        userLevel.Level__c = TritonTypes.Level.DEBUG.name();
+        userLevel.User_Id__c = UserInfo.getUserId();
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ userLevel };
+        TritonHelper.Config.logLevels = null;
+
+        Test.startTest();
+        TritonFlow.FlowLog blocked = TritonTestFactory.makeFlowLog('user-scoped blocked');
+        blocked.level = 'FINE';
+        TritonFlow.log(new List<TritonFlow.FlowLog>{ blocked });
+        TritonTestFactory.flushCachedFlowLogs();
+        Test.stopTest();
+
+        System.assertEquals(0, [SELECT COUNT() FROM pharos__Log__c WHERE pharos__Summary__c = 'user-scoped blocked'],
+            'The user-scoped DEBUG ceiling must suppress a FINE flow log');
+    }
+
+    /**
+     * LOG-2921: the optional flowVersion input maps to pharos__Flow_Version__c,
+     * matching the plain-name + separate-version convention of native flow logs.
+     */
+    @IsTest
+    private static void test_flow_version_passthrough() {
+        TritonTestFactory.assertNoLogs();
+        TritonTestFactory.resetFlowState();
+
+        TritonFlow.FlowLog withVersion = TritonTestFactory.makeFlowLog('with version');
+        withVersion.flowApiName = 'My_Flow';
+        withVersion.flowVersion = '4';
+
+        TritonFlow.FlowLog withoutVersion = TritonTestFactory.makeFlowLog('without version');
+        withoutVersion.flowApiName = 'My_Flow';
+
+        Test.startTest();
+        TritonFlow.log(new List<TritonFlow.FlowLog>{ withVersion, withoutVersion });
+        TritonTestFactory.flushCachedFlowLogs();
+        Test.stopTest();
+
+        List<pharos__Log__c> logs = [SELECT pharos__Summary__c, pharos__Flow_Version__c
+            FROM pharos__Log__c WHERE pharos__Summary__c IN ('with version', 'without version')
+            ORDER BY pharos__Summary__c];
+        System.assertEquals(2, logs.size(), 'Both logs must persist');
+        System.assertEquals('4', logs.get(0).pharos__Flow_Version__c,
+            'flowVersion input must map to pharos__Flow_Version__c (Text field, canonical numeric string)');
+        System.assertEquals(null, logs.get(1).pharos__Flow_Version__c,
+            'Omitted flowVersion must leave the field null');
+    }
+
+    /**
+     * LOG-2921: an unparsable flowVersion leaves the field null and appends a
+     * note to details, mirroring the invalid-level handling.
+     */
+    @IsTest
+    private static void test_flow_version_unparsable_noted_in_details() {
+        TritonTestFactory.assertNoLogs();
+        TritonTestFactory.resetFlowState();
+
+        TritonFlow.FlowLog bad = TritonTestFactory.makeFlowLog('bad version');
+        bad.flowVersion = 'four';
+
+        Test.startTest();
+        TritonFlow.log(new List<TritonFlow.FlowLog>{ bad });
+        TritonTestFactory.flushCachedFlowLogs();
+        Test.stopTest();
+
+        pharos__Log__c log = [SELECT pharos__Flow_Version__c, pharos__Details__c
+            FROM pharos__Log__c WHERE pharos__Summary__c = 'bad version'];
+        System.assertEquals(null, log.pharos__Flow_Version__c,
+            'An unparsable flowVersion must leave the field null');
+        System.assert(log.pharos__Details__c.contains('four'),
+            'The unparsable value must be noted in details (mirrors invalid-level handling). Got: ' + log.pharos__Details__c);
+    }
+
+    /**
      * Stacktrace is passed through to the output and persisted.
      */
     @IsTest

--- a/force-app/main/default/classes/TritonHelper.cls
+++ b/force-app/main/default/classes/TritonHelper.cls
@@ -689,7 +689,16 @@ public with sharing class TritonHelper {
                     logLevels = new List<LogLevelRule>();
                     componentScopedLevelsExist = false;
                     for (Log_Level__mdt ll : logLevelsMdt) {
-                        LogLevelRule rule = new LogLevelRule(ll);
+                        LogLevelRule rule;
+                        try {
+                            rule = new LogLevelRule(ll);
+                        } catch (Exception e) {
+                            // Fail-safe (matching isLoggingDisabled): a malformed row
+                            // (blank or unknown Level__c) becomes inert instead of
+                            // throwing into the host transaction and disabling all
+                            // filtering.
+                            continue;
+                        }
                         logLevels.add(rule);
                         componentScopedLevelsExist = componentScopedLevelsExist || rule.component != null;
                     }
@@ -808,9 +817,16 @@ public with sharing class TritonHelper {
         public Boolean isLogAllowed(pharos__Log__c log) {
             if (String.isBlank(log.Log_Level__c) || logLevels.isEmpty()) return true;
 
+            TritonTypes.Level currentLevel;
+            try {
+                currentLevel = TritonTypes.Level.valueOf(log.Log_Level__c);
+            } catch (Exception e) {
+                // Fail open: an unparsable log level must never drop the log.
+                return true;
+            }
+
             String logUserId = normalizeUserId(log.pharos__User_Id__c);
             String logComponent = getComponentName(log);
-            TritonTypes.Level currentLevel = TritonTypes.Level.valueOf(log.Log_Level__c);
 
             TritonTypes.Level effectiveLevel = null;
             Integer bestSpecificity = -1;
@@ -846,12 +862,16 @@ public with sharing class TritonHelper {
     * resolves to the class name rather than the literal 'Class'. LWC names
     * ('myComponent.Proxy.method') and explicitly supplied operations have no
     * prefix and are unaffected.
+    *
+    * Flow names may carry a legacy '-<version>' suffix (previously baked into
+    * flowApiName by X-ray instrumentation); that suffix is stripped for matching
+    * -- see stripVersionSuffix.
     * @param log -- Pharos log record being evaluated
     * @return the component name, or null/blank when it cannot be determined
     */
     @TestVisible
     private static String getComponentName(pharos__Log__c log) {
-        if (String.isNotBlank(log.pharos__Flow_API_Name__c)) return log.pharos__Flow_API_Name__c;
+        if (String.isNotBlank(log.pharos__Flow_API_Name__c)) return stripVersionSuffix(log.pharos__Flow_API_Name__c);
 
         String apexName = log.pharos__Apex_Name__c;
         if (String.isBlank(apexName)) return apexName;
@@ -861,19 +881,68 @@ public with sharing class TritonHelper {
         }
 
         Integer dotIndex = apexName.indexOf('.');
-        return dotIndex == -1 ? apexName : apexName.substring(0, dotIndex);
+        return stripVersionSuffix(dotIndex == -1 ? apexName : apexName.substring(0, dotIndex));
     }
 
     /**
-    * Salesforce Ids are 18 characters in Apex, but Log Level metadata stores the
-    * 15-character form. Matching is performed on the case-sensitive 15-character
-    * prefix so both representations line up.
+    * Normalizes a user Id to its case-safe 18-character form. Log Level metadata
+    * typically stores the 15-character form (case-SENSITIVE base 62) while log
+    * records carry the 18-character form; Id.valueOf expands the former to the
+    * latter, whose checksum suffix encodes the letter casing. Comparing the
+    * 18-character forms therefore lines both representations up without ever
+    * conflating two distinct users whose 15-character ids differ only in case.
+    * Fail-safe: an unparsable value normalizes to null rather than throwing.
+    * Id.valueOf accepts only well-formed ids (18-char values must carry their
+    * canonical checksum suffix), so a case-destroyed 18-char id is unparsable
+    * by design -- guessing at its casing would risk exactly the conflation
+    * this normalization exists to prevent.
+    * Callers that must distinguish blank (wildcard) from unparsable -- the rule
+    * parser -- compare against the raw value (see LogLevelRule).
     * @param userId -- a 15 or 18 character user Id (or null)
-    * @return the 15-character prefix, or the original value when shorter/blank
+    * @return the canonical 18-character Id string, or null when blank/unparsable
     */
     @TestVisible
     private static String normalizeUserId(String userId) {
-        return String.isNotBlank(userId) && userId.length() > 15 ? userId.substring(0, 15) : userId;
+        if (String.isBlank(userId)) return null;
+        try {
+            return String.valueOf(Id.valueOf(userId.trim()));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+    * Normalizes a Log_Level__mdt scope field to the documented blank-as-wildcard
+    * contract. Rows can arrive with null OR empty/whitespace values depending on
+    * how they were created (the console writes null; other tooling may write ''),
+    * and a non-null blank would otherwise count as a real value -- inflating
+    * specificity, breaking targeting, and falsely marking rules component-scoped.
+    * @param value -- raw rule field value
+    * @return null when blank, otherwise the trimmed value
+    */
+    @TestVisible
+    private static String normalizeRuleValue(String value) {
+        return String.isBlank(value) ? null : value.trim();
+    }
+
+    /**
+    * Strips a single trailing '-<digits>' from a component name. The dash is
+    * illegal in flow API names, Apex class names, and LWC component names, so a
+    * trailing '-N' can only be a flow-versioning artifact (the convention X-ray
+    * instrumentation used to bake into flowApiName). Applied to both sides of
+    * component matching so rules written with either form keep matching logs
+    * emitted with either form.
+    * @param name -- component name from a log or rule (post-normalization)
+    * @return the name without its version suffix, or unchanged when no suffix
+    */
+    @TestVisible
+    private static String stripVersionSuffix(String name) {
+        if (String.isBlank(name)) return name;
+        Integer dash = name.lastIndexOf('-');
+        if (dash <= 0) return name;
+        String suffix = name.substring(dash + 1);
+        // ''.isNumeric() is false, so a trailing bare '-' is kept.
+        return suffix.isNumeric() ? name.substring(0, dash) : name;
     }
 
     /**
@@ -903,6 +972,14 @@ public with sharing class TritonHelper {
         private final TritonTypes.Level level;
 
         /**
+        * True when User_Id__c held a non-blank value that is not a parsable Id.
+        * normalizeUserId turns such a value into null, which alone would read as
+        * "unspecified" and silently widen the rule to every user; this flag keeps
+        * the rule inert instead (fail-safe, matching malformed Level__c handling).
+        */
+        private final Boolean userIdUnmatchable;
+
+        /**
         * How narrowly this rule is scoped. Higher wins when several rules target
         * the same log. Computed once at parse time to keep the check allocation
         * free on the hot path.
@@ -910,11 +987,13 @@ public with sharing class TritonHelper {
         private final Integer specificity;
 
         private LogLevelRule(Log_Level__mdt mdt) {
-            this.category = mdt.Category__c;
-            this.type = mdt.Type__c;
-            this.area = mdt.Area__c;
-            this.userId = normalizeUserId(mdt.User_Id__c);
-            this.component = mdt.Component_Name__c;
+            this.category = normalizeRuleValue(mdt.Category__c);
+            this.type = normalizeRuleValue(mdt.Type__c);
+            this.area = normalizeRuleValue(mdt.Area__c);
+            String rawUserId = normalizeRuleValue(mdt.User_Id__c);
+            this.userId = normalizeUserId(rawUserId);
+            this.userIdUnmatchable = rawUserId != null && this.userId == null;
+            this.component = stripVersionSuffix(normalizeRuleValue(mdt.Component_Name__c));
             this.level = TritonTypes.Level.valueOf(mdt.Level__c);
             this.specificity =
                 (this.userId != null ? LEVEL_WEIGHT_USER_ID : 0) +
@@ -929,17 +1008,24 @@ public with sharing class TritonHelper {
         * Null (unspecified) rule attributes are treated as wildcards.
         */
         private Boolean targets(pharos__Log__c log, String logUserId, String logComponent) {
-            return matches(category, log.pharos__Category__c)
+            return !userIdUnmatchable
+                && matches(category, log.pharos__Category__c)
                 && matches(type, log.pharos__Type__c)
                 && matches(area, log.pharos__Area__c)
                 && matches(userId, logUserId)
                 && matches(component, logComponent);
         }
 
-        // String.equals is case-sensitive and null-safe, preserving the
-        // case-sensitivity required for 15-character Salesforce Ids.
+        // Case-insensitive, null-safe free-text comparison. Rule values are
+        // authored by admins in the console with no vocabulary constraint, so
+        // matching must be forgiving on case. User Ids are compared on their
+        // canonical 18-character forms (see normalizeUserId), where the
+        // checksum suffix encodes the letter casing of the significant 15
+        // chars -- so for user ids the case-insensitive compare degenerates
+        // to exact equality and cannot conflate two distinct users whose
+        // 15-char ids differ only in case.
         private Boolean matches(String ruleValue, String logValue) {
-            return ruleValue == null || ruleValue.equals(logValue);
+            return ruleValue == null || ruleValue.equalsIgnoreCase(logValue);
         }
     }
 }

--- a/force-app/main/default/classes/TritonHelper.cls
+++ b/force-app/main/default/classes/TritonHelper.cls
@@ -693,10 +693,8 @@ public with sharing class TritonHelper {
                         try {
                             rule = new LogLevelRule(ll);
                         } catch (Exception e) {
-                            // Fail-safe (matching isLoggingDisabled): a malformed row
-                            // (blank or unknown Level__c) becomes inert instead of
-                            // throwing into the host transaction and disabling all
-                            // filtering.
+                            // Fail-safe: a malformed row (e.g. blank Level__c) becomes
+                            // inert instead of throwing into the host transaction.
                             continue;
                         }
                         logLevels.add(rule);
@@ -862,16 +860,12 @@ public with sharing class TritonHelper {
     * resolves to the class name rather than the literal 'Class'. LWC names
     * ('myComponent.Proxy.method') and explicitly supplied operations have no
     * prefix and are unaffected.
-    *
-    * Flow names may carry a legacy '-<version>' suffix (previously baked into
-    * flowApiName by X-ray instrumentation); that suffix is stripped for matching
-    * -- see stripVersionSuffix.
     * @param log -- Pharos log record being evaluated
     * @return the component name, or null/blank when it cannot be determined
     */
     @TestVisible
     private static String getComponentName(pharos__Log__c log) {
-        if (String.isNotBlank(log.pharos__Flow_API_Name__c)) return stripVersionSuffix(log.pharos__Flow_API_Name__c);
+        if (String.isNotBlank(log.pharos__Flow_API_Name__c)) return log.pharos__Flow_API_Name__c;
 
         String apexName = log.pharos__Apex_Name__c;
         if (String.isBlank(apexName)) return apexName;
@@ -881,68 +875,31 @@ public with sharing class TritonHelper {
         }
 
         Integer dotIndex = apexName.indexOf('.');
-        return stripVersionSuffix(dotIndex == -1 ? apexName : apexName.substring(0, dotIndex));
+        return dotIndex == -1 ? apexName : apexName.substring(0, dotIndex);
     }
 
     /**
-    * Normalizes a user Id to its case-safe 18-character form. Log Level metadata
-    * typically stores the 15-character form (case-SENSITIVE base 62) while log
-    * records carry the 18-character form; Id.valueOf expands the former to the
-    * latter, whose checksum suffix encodes the letter casing. Comparing the
-    * 18-character forms therefore lines both representations up without ever
-    * conflating two distinct users whose 15-character ids differ only in case.
-    * Fail-safe: an unparsable value normalizes to null rather than throwing.
-    * Id.valueOf accepts only well-formed ids (18-char values must carry their
-    * canonical checksum suffix), so a case-destroyed 18-char id is unparsable
-    * by design -- guessing at its casing would risk exactly the conflation
-    * this normalization exists to prevent.
-    * Callers that must distinguish blank (wildcard) from unparsable -- the rule
-    * parser -- compare against the raw value (see LogLevelRule).
+    * Salesforce Ids are 18 characters in Apex, but Log Level metadata stores the
+    * 15-character form. Matching is performed on the case-sensitive 15-character
+    * prefix so both representations line up.
     * @param userId -- a 15 or 18 character user Id (or null)
-    * @return the canonical 18-character Id string, or null when blank/unparsable
+    * @return the 15-character prefix, or the original value when shorter/blank
     */
     @TestVisible
     private static String normalizeUserId(String userId) {
-        if (String.isBlank(userId)) return null;
-        try {
-            return String.valueOf(Id.valueOf(userId.trim()));
-        } catch (Exception e) {
-            return null;
-        }
+        return String.isNotBlank(userId) && userId.length() > 15 ? userId.substring(0, 15) : userId;
     }
 
     /**
-    * Normalizes a Log_Level__mdt scope field to the documented blank-as-wildcard
-    * contract. Rows can arrive with null OR empty/whitespace values depending on
-    * how they were created (the console writes null; other tooling may write ''),
-    * and a non-null blank would otherwise count as a real value -- inflating
-    * specificity, breaking targeting, and falsely marking rules component-scoped.
+    * Normalizes a Log_Level__mdt scope field to the blank-as-wildcard contract:
+    * rows can arrive with null or ''/whitespace blanks depending on the tooling
+    * that created them, and all must behave the same.
     * @param value -- raw rule field value
     * @return null when blank, otherwise the trimmed value
     */
     @TestVisible
     private static String normalizeRuleValue(String value) {
         return String.isBlank(value) ? null : value.trim();
-    }
-
-    /**
-    * Strips a single trailing '-<digits>' from a component name. The dash is
-    * illegal in flow API names, Apex class names, and LWC component names, so a
-    * trailing '-N' can only be a flow-versioning artifact (the convention X-ray
-    * instrumentation used to bake into flowApiName). Applied to both sides of
-    * component matching so rules written with either form keep matching logs
-    * emitted with either form.
-    * @param name -- component name from a log or rule (post-normalization)
-    * @return the name without its version suffix, or unchanged when no suffix
-    */
-    @TestVisible
-    private static String stripVersionSuffix(String name) {
-        if (String.isBlank(name)) return name;
-        Integer dash = name.lastIndexOf('-');
-        if (dash <= 0) return name;
-        String suffix = name.substring(dash + 1);
-        // ''.isNumeric() is false, so a trailing bare '-' is kept.
-        return suffix.isNumeric() ? name.substring(0, dash) : name;
     }
 
     /**
@@ -972,14 +929,6 @@ public with sharing class TritonHelper {
         private final TritonTypes.Level level;
 
         /**
-        * True when User_Id__c held a non-blank value that is not a parsable Id.
-        * normalizeUserId turns such a value into null, which alone would read as
-        * "unspecified" and silently widen the rule to every user; this flag keeps
-        * the rule inert instead (fail-safe, matching malformed Level__c handling).
-        */
-        private final Boolean userIdUnmatchable;
-
-        /**
         * How narrowly this rule is scoped. Higher wins when several rules target
         * the same log. Computed once at parse time to keep the check allocation
         * free on the hot path.
@@ -990,10 +939,8 @@ public with sharing class TritonHelper {
             this.category = normalizeRuleValue(mdt.Category__c);
             this.type = normalizeRuleValue(mdt.Type__c);
             this.area = normalizeRuleValue(mdt.Area__c);
-            String rawUserId = normalizeRuleValue(mdt.User_Id__c);
-            this.userId = normalizeUserId(rawUserId);
-            this.userIdUnmatchable = rawUserId != null && this.userId == null;
-            this.component = stripVersionSuffix(normalizeRuleValue(mdt.Component_Name__c));
+            this.userId = normalizeUserId(normalizeRuleValue(mdt.User_Id__c));
+            this.component = normalizeRuleValue(mdt.Component_Name__c);
             this.level = TritonTypes.Level.valueOf(mdt.Level__c);
             this.specificity =
                 (this.userId != null ? LEVEL_WEIGHT_USER_ID : 0) +
@@ -1008,22 +955,16 @@ public with sharing class TritonHelper {
         * Null (unspecified) rule attributes are treated as wildcards.
         */
         private Boolean targets(pharos__Log__c log, String logUserId, String logComponent) {
-            return !userIdUnmatchable
-                && matches(category, log.pharos__Category__c)
+            // User ids compare case-sensitively (15-char Ids are case-sensitive base 62).
+            return matches(category, log.pharos__Category__c)
                 && matches(type, log.pharos__Type__c)
                 && matches(area, log.pharos__Area__c)
-                && matches(userId, logUserId)
+                && (userId == null || userId.equals(logUserId))
                 && matches(component, logComponent);
         }
 
-        // Case-insensitive, null-safe free-text comparison. Rule values are
-        // authored by admins in the console with no vocabulary constraint, so
-        // matching must be forgiving on case. User Ids are compared on their
-        // canonical 18-character forms (see normalizeUserId), where the
-        // checksum suffix encodes the letter casing of the significant 15
-        // chars -- so for user ids the case-insensitive compare degenerates
-        // to exact equality and cannot conflate two distinct users whose
-        // 15-char ids differ only in case.
+        // Case-insensitive, null-safe comparison: rule values are free text
+        // authored in the console, so matching must be forgiving on case.
         private Boolean matches(String ruleValue, String logValue) {
             return ruleValue == null || ruleValue.equalsIgnoreCase(logValue);
         }

--- a/force-app/main/default/classes/TritonTest.cls
+++ b/force-app/main/default/classes/TritonTest.cls
@@ -572,12 +572,382 @@ private class TritonTest {
 
     @IsTest
     private static void test_normalize_user_id() {
-        Id userId = UserInfo.getUserId();
-        System.assertEquals(String.valueOf(userId).substring(0, 15), TritonHelper.normalizeUserId(userId),
-            '18-character Id should be truncated to its 15-character prefix');
-        System.assertEquals('015CHAR00000000', TritonHelper.normalizeUserId('015CHAR00000000'),
-            '15-character value should be returned unchanged');
+        String userId18 = UserInfo.getUserId();
+        System.assertEquals(userId18, TritonHelper.normalizeUserId(userId18.substring(0, 15)),
+            '15-character Id should expand to its case-safe 18-character form');
+        System.assertEquals(userId18, TritonHelper.normalizeUserId(userId18),
+            '18-character Id should normalize to its canonical 18-character form');
         System.assertEquals(null, TritonHelper.normalizeUserId(null));
+        System.assertEquals(null, TritonHelper.normalizeUserId('not-an-id'),
+            'An unparsable value must normalize to null (fail-safe), never throw');
+    }
+
+    // --- LOG-2921: blank-as-wildcard, case-insensitive free-text matching ---
+
+    // The three CMDT blank shapes a rule field can arrive in, depending on how
+    // the row was created. All must behave identically (wildcard).
+    private static List<String> blankShapes() {
+        return new List<String>{ null, '', '  ' };
+    }
+
+    @IsTest
+    private static void test_blank_rule_fields_are_wildcards_in_every_shape() {
+        for (String blank : blankShapes()) {
+            Log_Level__mdt rule = new Log_Level__mdt();
+            rule.Level__c = TritonTypes.Level.INFO.name();
+            rule.Category__c = 'Event';
+            rule.Type__c = blank;
+            rule.Area__c = blank;
+            rule.User_Id__c = blank;
+            rule.Component_Name__c = blank;
+            TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ rule };
+            TritonHelper.Config.logLevels = null;
+
+            pharos__Log__c log = new pharos__Log__c(
+                Log_Level__c = TritonTypes.Level.DEBUG.name(),
+                pharos__Category__c = 'Event',
+                pharos__Type__c = 'Backend',
+                pharos__Area__c = 'Community');
+            System.assertEquals(false, TritonHelper.Config.isLogAllowed(log),
+                'Blank fields (shape "' + blank + '") must be wildcards: the INFO rule targets the log and blocks DEBUG');
+            System.assertEquals(false, TritonHelper.Config.hasComponentScopedLevels(),
+                'A blank Component_Name__c (shape "' + blank + '") must not mark the rule component-scoped');
+        }
+    }
+
+    @IsTest
+    private static void test_blank_rule_fields_do_not_inflate_specificity() {
+        // If '' counted as a value, the second rule would either fail to target the
+        // log (component mismatch) or outrank the first. Normalized, both rules are
+        // category-only, equally specific, and the tie resolves to WARNING.
+        for (String blank : blankShapes()) {
+            Log_Level__mdt verbose = new Log_Level__mdt();
+            verbose.Level__c = TritonTypes.Level.FINEST.name();
+            verbose.Category__c = 'Event';
+
+            Log_Level__mdt restrictive = new Log_Level__mdt();
+            restrictive.Level__c = TritonTypes.Level.WARNING.name();
+            restrictive.Category__c = 'Event';
+            restrictive.Component_Name__c = blank;
+
+            TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ verbose, restrictive };
+            TritonHelper.Config.logLevels = null;
+
+            pharos__Log__c log = new pharos__Log__c(
+                Log_Level__c = TritonTypes.Level.INFO.name(),
+                pharos__Category__c = 'Event',
+                pharos__Apex_Name__c = 'AnyComponent.method');
+            System.assertEquals(false, TritonHelper.Config.isLogAllowed(log),
+                'Shape "' + blank + '": blank component must not add specificity or break targeting; tie-break must yield WARNING');
+        }
+    }
+
+    @IsTest
+    private static void test_rule_values_are_trimmed() {
+        Log_Level__mdt rule = new Log_Level__mdt();
+        rule.Level__c = TritonTypes.Level.INFO.name();
+        rule.Area__c = ' Partners ';
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ rule };
+        TritonHelper.Config.logLevels = null;
+
+        pharos__Log__c log = new pharos__Log__c(
+            Log_Level__c = TritonTypes.Level.DEBUG.name(),
+            pharos__Area__c = 'Partners');
+        System.assertEquals(false, TritonHelper.Config.isLogAllowed(log),
+            'Rule values must be trimmed before matching');
+    }
+
+    @IsTest
+    private static void test_matching_is_case_insensitive_for_all_fields() {
+        // Free-text values, deliberately NOT TritonTypes enum members: matching is
+        // pure free text with no vocabulary constraint.
+        Log_Level__mdt rule = new Log_Level__mdt();
+        rule.Level__c = TritonTypes.Level.INFO.name();
+        rule.Category__c = 'fLoW';
+        rule.Type__c = 'screen flow';
+        rule.Area__c = 'PARTNERS';
+        rule.Component_Name__c = 'partner_intake_form';
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ rule };
+        TritonHelper.Config.logLevels = null;
+
+        pharos__Log__c log = new pharos__Log__c(
+            Log_Level__c = TritonTypes.Level.DEBUG.name(),
+            pharos__Category__c = 'Flow',
+            pharos__Type__c = 'Screen Flow',
+            pharos__Area__c = 'Partners',
+            pharos__Flow_API_Name__c = 'Partner_Intake_Form');
+        System.assertEquals(false, TritonHelper.Config.isLogAllowed(log),
+            'All fields must match case-insensitively as free text');
+
+        // A genuinely different value must still miss.
+        log.pharos__Type__c = 'Autolaunched Flow';
+        System.assertEquals(true, TritonHelper.Config.isLogAllowed(log),
+            'Case-insensitivity must not turn into substring/fuzzy matching');
+    }
+
+    @IsTest
+    private static void test_user_id_matching_ignores_length_via_18_char_form() {
+        String userId18 = UserInfo.getUserId();
+        String userId15 = userId18.substring(0, 15);
+        // 15-char and 18-char rule forms must both match a log carrying either
+        // form of the same id: matching is length-insensitive via canonical
+        // 18-char expansion. No case variants here -- the significant 15 chars
+        // are case-SENSITIVE base 62, so re-casing them denotes a DIFFERENT
+        // record (see the conflation test below), and Id.valueOf validates the
+        // 18-char checksum suffix case-sensitively, so a re-cased suffix is
+        // unparsable and falls under the inert fail-safe (pinned in
+        // test_invalid_user_id_rule_value_is_inert_not_fatal).
+        for (String ruleValue : new List<String>{ userId15, userId18 }) {
+            Log_Level__mdt rule = new Log_Level__mdt();
+            rule.Level__c = TritonTypes.Level.INFO.name();
+            rule.User_Id__c = ruleValue;
+            TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ rule };
+            TritonHelper.Config.logLevels = null;
+
+            pharos__Log__c log = new pharos__Log__c(
+                Log_Level__c = TritonTypes.Level.DEBUG.name(),
+                pharos__User_Id__c = userId18);
+            System.assertEquals(false, TritonHelper.Config.isLogAllowed(log),
+                'Rule user id "' + ruleValue + '" must match the 18-char log value');
+
+            // And the mirror: 15-char log value against the same rule.
+            log.pharos__User_Id__c = userId15;
+            System.assertEquals(false, TritonHelper.Config.isLogAllowed(log),
+                'Rule user id "' + ruleValue + '" must match a 15-char log value');
+        }
+
+        // A different user still misses.
+        Log_Level__mdt other = new Log_Level__mdt();
+        other.Level__c = TritonTypes.Level.INFO.name();
+        other.User_Id__c = '005000000000001';
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ other };
+        TritonHelper.Config.logLevels = null;
+        System.assertEquals(true, TritonHelper.Config.isLogAllowed(new pharos__Log__c(
+                Log_Level__c = TritonTypes.Level.DEBUG.name(),
+                pharos__User_Id__c = userId18)),
+            'A rule for a different user must not target this log');
+    }
+
+    @IsTest
+    private static void test_user_ids_differing_only_in_15_char_case_do_not_conflate() {
+        // Salesforce 15-char ids are case-sensitive base 62: '...Aaa' and '...AaA'
+        // are two DISTINCT users, distinguishable only by letter case. Matching on
+        // a case-insensitive 15-char prefix would conflate them; normalizing both
+        // sides to the 18-char form (whose suffix encodes the casing) must not.
+        String userA15 = '005000000000Aaa';
+        String userB15 = '005000000000AaA';
+
+        Log_Level__mdt rule = new Log_Level__mdt();
+        rule.Level__c = TritonTypes.Level.INFO.name();
+        rule.User_Id__c = userA15;
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ rule };
+        TritonHelper.Config.logLevels = null;
+
+        pharos__Log__c log = new pharos__Log__c(
+            Log_Level__c = TritonTypes.Level.DEBUG.name(),
+            pharos__User_Id__c = String.valueOf(Id.valueOf(userB15)));
+        System.assertEquals(true, TritonHelper.Config.isLogAllowed(log),
+            'A rule scoped to user ...Aaa must NOT target user ...AaA');
+
+        // Sanity: the same rule still targets its own user.
+        log.pharos__User_Id__c = String.valueOf(Id.valueOf(userA15));
+        System.assertEquals(false, TritonHelper.Config.isLogAllowed(log),
+            'The rule must still target its own user');
+    }
+
+    @IsTest
+    private static void test_invalid_user_id_rule_value_is_inert_not_fatal() {
+        // An unparsable User_Id__c value (fat-fingered paste, wrong column, a
+        // case-destroyed 18-char id -- Id.valueOf validates the checksum suffix
+        // case-sensitively) must neither throw into the host transaction nor
+        // match anything: not any user, and NOT everything (it must not degrade
+        // into a wildcard). The last shape is deliberately the CURRENT user's id
+        // with a re-cased suffix: guessing at it would risk conflation, so even
+        // a near-miss stays inert. Sibling rules keep working, matching the
+        // malformed-Level__c fail-safe.
+        String userId18 = UserInfo.getUserId();
+        for (String badValue : new List<String>{ 'not-an-id', 'short', '005!0000000000W', '005000000000000000000',
+                                                 userId18.substring(0, 15) + userId18.substring(15).toLowerCase() }) {
+            Log_Level__mdt malformed = new Log_Level__mdt();
+            malformed.Level__c = TritonTypes.Level.INFO.name();
+            malformed.User_Id__c = badValue;
+
+            Log_Level__mdt sibling = new Log_Level__mdt();
+            sibling.Level__c = TritonTypes.Level.INFO.name();
+            sibling.Area__c = 'Community';
+
+            TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ malformed, sibling };
+            TritonHelper.Config.logLevels = null;
+
+            pharos__Log__c log = new pharos__Log__c(
+                Log_Level__c = TritonTypes.Level.DEBUG.name(),
+                pharos__User_Id__c = UserInfo.getUserId());
+            System.assertEquals(true, TritonHelper.Config.isLogAllowed(log),
+                'Rule value "' + badValue + '" must match no log at all -- neither this user nor as a wildcard');
+
+            // The sibling rule still targets and filters its own scope.
+            log.pharos__Area__c = 'Community';
+            System.assertEquals(false, TritonHelper.Config.isLogAllowed(log),
+                'Rule value "' + badValue + '" must not disable the sibling Area rule');
+
+            // An unparsable log-side user id must not throw either: user-scoped
+            // rules simply cannot target it, while non-user rules still apply.
+            System.assertEquals(false, TritonHelper.Config.isLogAllowed(new pharos__Log__c(
+                    Log_Level__c = TritonTypes.Level.DEBUG.name(),
+                    pharos__Area__c = 'Community',
+                    pharos__User_Id__c = 'garbage-user-id')),
+                'Rule value "' + badValue + '": an unparsable log user id must not throw or bypass sibling rules');
+        }
+    }
+
+    @IsTest
+    private static void test_malformed_rule_level_is_inert_not_fatal() {
+        // One malformed row (blank or garbage Level__c, in any blank shape) must
+        // not throw inside the caller's transaction or disable sibling rules.
+        for (String badLevel : new List<String>{ null, '', '  ', 'VERBOSE' }) {
+            Log_Level__mdt malformed = new Log_Level__mdt();
+            malformed.Level__c = badLevel;
+            malformed.Category__c = 'Event';
+
+            Log_Level__mdt sibling = new Log_Level__mdt();
+            sibling.Level__c = TritonTypes.Level.INFO.name();
+            sibling.Area__c = 'Community';
+
+            TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ malformed, sibling };
+            TritonHelper.Config.logLevels = null;
+
+            System.assertEquals(1, TritonHelper.Config.logLevels.size(),
+                'Level "' + badLevel + '": the malformed rule must be skipped, the sibling kept');
+            System.assertEquals(false, TritonHelper.Config.isLogAllowed(new pharos__Log__c(
+                    Log_Level__c = TritonTypes.Level.DEBUG.name(),
+                    pharos__Area__c = 'Community')),
+                'Level "' + badLevel + '": the sibling rule must still enforce its threshold');
+        }
+    }
+
+    @IsTest
+    private static void test_unparsable_log_level_fails_open() {
+        Log_Level__mdt rule = new Log_Level__mdt();
+        rule.Level__c = TritonTypes.Level.ERROR.name();
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ rule };
+        TritonHelper.Config.logLevels = null;
+
+        System.assertEquals(true, TritonHelper.Config.isLogAllowed(new pharos__Log__c(
+                Log_Level__c = 'NOT_A_LEVEL')),
+            'A log whose level cannot be parsed must be allowed through, not dropped or thrown on');
+    }
+
+    @IsTest
+    private static void test_component_version_suffix_tolerance() {
+        // getComponentName strips a single trailing '-<digits>' (flow versioning
+        // artifact; '-' is illegal in flow/Apex/LWC API names).
+        System.assertEquals('Partner_Intake_Form', TritonHelper.getComponentName(
+            new pharos__Log__c(pharos__Flow_API_Name__c = 'Partner_Intake_Form-4')));
+        System.assertEquals('Partner_Intake_Form', TritonHelper.getComponentName(
+            new pharos__Log__c(pharos__Flow_API_Name__c = 'Partner_Intake_Form')));
+        // Non-artifact dashes are kept.
+        System.assertEquals('X-4a', TritonHelper.getComponentName(
+            new pharos__Log__c(pharos__Flow_API_Name__c = 'X-4a')));
+        System.assertEquals('X-', TritonHelper.getComponentName(
+            new pharos__Log__c(pharos__Flow_API_Name__c = 'X-')));
+        // Apex/LWC resolution unaffected.
+        System.assertEquals('AccountService', TritonHelper.getComponentName(
+            new pharos__Log__c(pharos__Apex_Name__c = 'Class.AccountService.updateAccounts')));
+
+        // Suffixed log matches rules written either way; plain log matches both.
+        for (String ruleComponent : new List<String>{ 'Partner_Intake_Form', 'Partner_Intake_Form-4' }) {
+            for (String logFlowName : new List<String>{ 'Partner_Intake_Form', 'Partner_Intake_Form-4' }) {
+                Log_Level__mdt rule = new Log_Level__mdt();
+                rule.Level__c = TritonTypes.Level.INFO.name();
+                rule.Component_Name__c = ruleComponent;
+                TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ rule };
+                TritonHelper.Config.logLevels = null;
+
+                System.assertEquals(false, TritonHelper.Config.isLogAllowed(new pharos__Log__c(
+                        Log_Level__c = TritonTypes.Level.DEBUG.name(),
+                        pharos__Flow_API_Name__c = logFlowName)),
+                    'Rule "' + ruleComponent + '" must target flow log "' + logFlowName + '"');
+            }
+        }
+    }
+
+    @IsTest
+    private static void test_qa_matrix_shapes_against_real_flow_log() {
+        // Reproduces the exact log shape from QA's X-ray-instrumented flow runs
+        // (spec §1.3) with the post-fix emission behavior (user stamped). One rule
+        // per matrix group; each INFO rule must block the DEBUG log.
+        pharos__Log__c flowLog = new pharos__Log__c(
+            Log_Level__c = TritonTypes.Level.DEBUG.name(),
+            pharos__Category__c = 'Flow',
+            pharos__Type__c = 'Screen Flow',
+            pharos__Area__c = 'Partners',
+            pharos__Flow_API_Name__c = 'Partner_Intake_Form-4',
+            pharos__Apex_Name__c = 'Start',
+            pharos__User_Id__c = UserInfo.getUserId());
+
+        Map<String, Log_Level__mdt> rulesByGroup = new Map<String, Log_Level__mdt>();
+
+        Log_Level__mdt categoryRule = new Log_Level__mdt();
+        categoryRule.Level__c = 'INFO'; categoryRule.Category__c = 'flow';
+        rulesByGroup.put('+Category', categoryRule);
+
+        Log_Level__mdt typeRule = new Log_Level__mdt();
+        typeRule.Level__c = 'INFO'; typeRule.Type__c = 'screen flow';
+        rulesByGroup.put('+Type', typeRule);
+
+        Log_Level__mdt areaRule = new Log_Level__mdt();
+        areaRule.Level__c = 'INFO'; areaRule.Area__c = 'partners';
+        rulesByGroup.put('+Area', areaRule);
+
+        Log_Level__mdt componentRule = new Log_Level__mdt();
+        componentRule.Level__c = 'INFO'; componentRule.Component_Name__c = 'Partner_Intake_Form';
+        rulesByGroup.put('+Component', componentRule);
+
+        Log_Level__mdt userRule = new Log_Level__mdt();
+        userRule.Level__c = 'INFO'; userRule.User_Id__c = UserInfo.getUserId().substring(0, 15);
+        rulesByGroup.put('+User', userRule);
+
+        for (String grp : rulesByGroup.keySet()) {
+            TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ rulesByGroup.get(grp) };
+            TritonHelper.Config.logLevels = null;
+            System.assertEquals(false, TritonHelper.Config.isLogAllowed(flowLog),
+                grp + ' rule must target the real flow-log shape and block DEBUG');
+        }
+    }
+
+    // --- LOG-2921: emission-time user stamping -----------------------------
+
+    @IsTest
+    private static void test_builder_stamps_running_user_at_emission() {
+        System.assertEquals(UserInfo.getUserId(), Triton.makeBuilder().build().pharos__User_Id__c,
+            'Every builder must carry the running user so User-scoped rules match at filter time');
+    }
+
+    @IsTest
+    private static void test_explicit_user_id_overrides_stamp() {
+        Id otherUser = '005000000000001AAA';
+        TritonBuilder builder = Triton.makeBuilder().userId(otherUser);
+        System.assertEquals(otherUser, builder.build().pharos__User_Id__c,
+            'An explicit .userId() must override the emission-time stamp');
+        System.assertEquals(otherUser, builder.cloneBuilder().build().pharos__User_Id__c,
+            'cloneBuilder must preserve an explicit user id, not re-stamp the running user');
+    }
+
+    @IsTest
+    private static void test_user_rule_matches_apex_log_without_explicit_user() {
+        TritonTestFactory.assertNoLogs();
+
+        // Pre-fix, Apex logs carried no user at filter time, so User-scoped rules
+        // never matched them. The stamp makes this rule bite with no .userId() call.
+        setupUserIdLogLevel(UserInfo.getUserId());
+
+        Test.startTest();
+        Triton.logNow(Triton.t.category(TritonTypes.Category.Event).type(TritonTypes.Type.Backend).area(TritonTypes.Area.Community)
+            .summary('no explicit user').details('details').level(TritonTypes.Level.FINE));
+        Test.stopTest();
+
+        System.assertEquals(0, [SELECT COUNT() FROM pharos__Log__c WHERE pharos__Category__c = :TritonTypes.Category.Event.name()],
+            'The user-scoped DEBUG ceiling must suppress a FINE Apex log that never called .userId()');
     }
 
     @IsTest

--- a/force-app/main/default/classes/TritonTest.cls
+++ b/force-app/main/default/classes/TritonTest.cls
@@ -572,14 +572,12 @@ private class TritonTest {
 
     @IsTest
     private static void test_normalize_user_id() {
-        String userId18 = UserInfo.getUserId();
-        System.assertEquals(userId18, TritonHelper.normalizeUserId(userId18.substring(0, 15)),
-            '15-character Id should expand to its case-safe 18-character form');
-        System.assertEquals(userId18, TritonHelper.normalizeUserId(userId18),
-            '18-character Id should normalize to its canonical 18-character form');
+        Id userId = UserInfo.getUserId();
+        System.assertEquals(String.valueOf(userId).substring(0, 15), TritonHelper.normalizeUserId(userId),
+            '18-character Id should be truncated to its 15-character prefix');
+        System.assertEquals('015CHAR00000000', TritonHelper.normalizeUserId('015CHAR00000000'),
+            '15-character value should be returned unchanged');
         System.assertEquals(null, TritonHelper.normalizeUserId(null));
-        System.assertEquals(null, TritonHelper.normalizeUserId('not-an-id'),
-            'An unparsable value must normalize to null (fail-safe), never throw');
     }
 
     // --- LOG-2921: blank-as-wildcard, case-insensitive free-text matching ---
@@ -658,7 +656,7 @@ private class TritonTest {
     }
 
     @IsTest
-    private static void test_matching_is_case_insensitive_for_all_fields() {
+    private static void test_matching_is_case_insensitive_for_free_text_fields() {
         // Free-text values, deliberately NOT TritonTypes enum members: matching is
         // pure free text with no vocabulary constraint.
         Log_Level__mdt rule = new Log_Level__mdt();
@@ -686,17 +684,10 @@ private class TritonTest {
     }
 
     @IsTest
-    private static void test_user_id_matching_ignores_length_via_18_char_form() {
+    private static void test_user_id_matching_is_length_insensitive_and_case_exact() {
         String userId18 = UserInfo.getUserId();
         String userId15 = userId18.substring(0, 15);
-        // 15-char and 18-char rule forms must both match a log carrying either
-        // form of the same id: matching is length-insensitive via canonical
-        // 18-char expansion. No case variants here -- the significant 15 chars
-        // are case-SENSITIVE base 62, so re-casing them denotes a DIFFERENT
-        // record (see the conflation test below), and Id.valueOf validates the
-        // 18-char checksum suffix case-sensitively, so a re-cased suffix is
-        // unparsable and falls under the inert fail-safe (pinned in
-        // test_invalid_user_id_rule_value_is_inert_not_fatal).
+        // 15- and 18-char forms of the same id match via 15-char prefix truncation.
         for (String ruleValue : new List<String>{ userId15, userId18 }) {
             Log_Level__mdt rule = new Log_Level__mdt();
             rule.Level__c = TritonTypes.Level.INFO.name();
@@ -726,78 +717,17 @@ private class TritonTest {
                 Log_Level__c = TritonTypes.Level.DEBUG.name(),
                 pharos__User_Id__c = userId18)),
             'A rule for a different user must not target this log');
-    }
 
-    @IsTest
-    private static void test_user_ids_differing_only_in_15_char_case_do_not_conflate() {
-        // Salesforce 15-char ids are case-sensitive base 62: '...Aaa' and '...AaA'
-        // are two DISTINCT users, distinguishable only by letter case. Matching on
-        // a case-insensitive 15-char prefix would conflate them; normalizing both
-        // sides to the 18-char form (whose suffix encodes the casing) must not.
-        String userA15 = '005000000000Aaa';
-        String userB15 = '005000000000AaA';
-
-        Log_Level__mdt rule = new Log_Level__mdt();
-        rule.Level__c = TritonTypes.Level.INFO.name();
-        rule.User_Id__c = userA15;
-        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ rule };
+        // Case-exact: 15-char ids are case-sensitive base 62.
+        Log_Level__mdt cased = new Log_Level__mdt();
+        cased.Level__c = TritonTypes.Level.INFO.name();
+        cased.User_Id__c = '005000000000Aaa';
+        TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ cased };
         TritonHelper.Config.logLevels = null;
-
-        pharos__Log__c log = new pharos__Log__c(
-            Log_Level__c = TritonTypes.Level.DEBUG.name(),
-            pharos__User_Id__c = String.valueOf(Id.valueOf(userB15)));
-        System.assertEquals(true, TritonHelper.Config.isLogAllowed(log),
-            'A rule scoped to user ...Aaa must NOT target user ...AaA');
-
-        // Sanity: the same rule still targets its own user.
-        log.pharos__User_Id__c = String.valueOf(Id.valueOf(userA15));
-        System.assertEquals(false, TritonHelper.Config.isLogAllowed(log),
-            'The rule must still target its own user');
-    }
-
-    @IsTest
-    private static void test_invalid_user_id_rule_value_is_inert_not_fatal() {
-        // An unparsable User_Id__c value (fat-fingered paste, wrong column, a
-        // case-destroyed 18-char id -- Id.valueOf validates the checksum suffix
-        // case-sensitively) must neither throw into the host transaction nor
-        // match anything: not any user, and NOT everything (it must not degrade
-        // into a wildcard). The last shape is deliberately the CURRENT user's id
-        // with a re-cased suffix: guessing at it would risk conflation, so even
-        // a near-miss stays inert. Sibling rules keep working, matching the
-        // malformed-Level__c fail-safe.
-        String userId18 = UserInfo.getUserId();
-        for (String badValue : new List<String>{ 'not-an-id', 'short', '005!0000000000W', '005000000000000000000',
-                                                 userId18.substring(0, 15) + userId18.substring(15).toLowerCase() }) {
-            Log_Level__mdt malformed = new Log_Level__mdt();
-            malformed.Level__c = TritonTypes.Level.INFO.name();
-            malformed.User_Id__c = badValue;
-
-            Log_Level__mdt sibling = new Log_Level__mdt();
-            sibling.Level__c = TritonTypes.Level.INFO.name();
-            sibling.Area__c = 'Community';
-
-            TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ malformed, sibling };
-            TritonHelper.Config.logLevels = null;
-
-            pharos__Log__c log = new pharos__Log__c(
+        System.assertEquals(true, TritonHelper.Config.isLogAllowed(new pharos__Log__c(
                 Log_Level__c = TritonTypes.Level.DEBUG.name(),
-                pharos__User_Id__c = UserInfo.getUserId());
-            System.assertEquals(true, TritonHelper.Config.isLogAllowed(log),
-                'Rule value "' + badValue + '" must match no log at all -- neither this user nor as a wildcard');
-
-            // The sibling rule still targets and filters its own scope.
-            log.pharos__Area__c = 'Community';
-            System.assertEquals(false, TritonHelper.Config.isLogAllowed(log),
-                'Rule value "' + badValue + '" must not disable the sibling Area rule');
-
-            // An unparsable log-side user id must not throw either: user-scoped
-            // rules simply cannot target it, while non-user rules still apply.
-            System.assertEquals(false, TritonHelper.Config.isLogAllowed(new pharos__Log__c(
-                    Log_Level__c = TritonTypes.Level.DEBUG.name(),
-                    pharos__Area__c = 'Community',
-                    pharos__User_Id__c = 'garbage-user-id')),
-                'Rule value "' + badValue + '": an unparsable log user id must not throw or bypass sibling rules');
-        }
+                pharos__User_Id__c = '005000000000AaA')),
+            'User id matching must stay case-sensitive');
     }
 
     @IsTest
@@ -838,50 +768,17 @@ private class TritonTest {
     }
 
     @IsTest
-    private static void test_component_version_suffix_tolerance() {
-        // getComponentName strips a single trailing '-<digits>' (flow versioning
-        // artifact; '-' is illegal in flow/Apex/LWC API names).
-        System.assertEquals('Partner_Intake_Form', TritonHelper.getComponentName(
-            new pharos__Log__c(pharos__Flow_API_Name__c = 'Partner_Intake_Form-4')));
-        System.assertEquals('Partner_Intake_Form', TritonHelper.getComponentName(
-            new pharos__Log__c(pharos__Flow_API_Name__c = 'Partner_Intake_Form')));
-        // Non-artifact dashes are kept.
-        System.assertEquals('X-4a', TritonHelper.getComponentName(
-            new pharos__Log__c(pharos__Flow_API_Name__c = 'X-4a')));
-        System.assertEquals('X-', TritonHelper.getComponentName(
-            new pharos__Log__c(pharos__Flow_API_Name__c = 'X-')));
-        // Apex/LWC resolution unaffected.
-        System.assertEquals('AccountService', TritonHelper.getComponentName(
-            new pharos__Log__c(pharos__Apex_Name__c = 'Class.AccountService.updateAccounts')));
-
-        // Suffixed log matches rules written either way; plain log matches both.
-        for (String ruleComponent : new List<String>{ 'Partner_Intake_Form', 'Partner_Intake_Form-4' }) {
-            for (String logFlowName : new List<String>{ 'Partner_Intake_Form', 'Partner_Intake_Form-4' }) {
-                Log_Level__mdt rule = new Log_Level__mdt();
-                rule.Level__c = TritonTypes.Level.INFO.name();
-                rule.Component_Name__c = ruleComponent;
-                TritonHelper.Config.logLevelsMdt = new Log_Level__mdt[]{ rule };
-                TritonHelper.Config.logLevels = null;
-
-                System.assertEquals(false, TritonHelper.Config.isLogAllowed(new pharos__Log__c(
-                        Log_Level__c = TritonTypes.Level.DEBUG.name(),
-                        pharos__Flow_API_Name__c = logFlowName)),
-                    'Rule "' + ruleComponent + '" must target flow log "' + logFlowName + '"');
-            }
-        }
-    }
-
-    @IsTest
     private static void test_qa_matrix_shapes_against_real_flow_log() {
-        // Reproduces the exact log shape from QA's X-ray-instrumented flow runs
-        // (spec §1.3) with the post-fix emission behavior (user stamped). One rule
-        // per matrix group; each INFO rule must block the DEBUG log.
+        // QA's flow-log shape (spec §1.3) with the post-fix emission convention:
+        // plain flow API name, separate version, user stamped. One rule per matrix
+        // group; each INFO rule must block the DEBUG log.
         pharos__Log__c flowLog = new pharos__Log__c(
             Log_Level__c = TritonTypes.Level.DEBUG.name(),
             pharos__Category__c = 'Flow',
             pharos__Type__c = 'Screen Flow',
             pharos__Area__c = 'Partners',
-            pharos__Flow_API_Name__c = 'Partner_Intake_Form-4',
+            pharos__Flow_API_Name__c = 'Partner_Intake_Form',
+            pharos__Flow_Version__c = '4',
             pharos__Apex_Name__c = 'Start',
             pharos__User_Id__c = UserInfo.getUserId());
 


### PR DESCRIPTION
Fixes the Log Level rules feature per QA findings from LOG-2904 (ticket item I). Root causes were pinned by an on-org investigation with per-matrix-group reproduction; the engine's comparison logic was sound — the failures came from field values never being present or matchable at filter time.
