### PR TITLE
LOG-2927: Deprecate the Integration log category — fold into Apex

### DIFF
--- a/agent-skills/instrument-apex.md
+++ b/agent-skills/instrument-apex.md
@@ -37,7 +37,7 @@ If the output contains `"status": "error"` or no default org is set → stop and
 From the skill arguments:
 - **File path** — the `.cls` or `.trigger` file to instrument (required). If not provided, ask: "Which Apex class or trigger file do you want to instrument? (provide the path)"
 - **`--area`** — the business/functional area for these logs. **Infer this from the code and keep it consistent with related code** (Step 2) — it is the primary key for grouping and searching in Pharos. `.area()` takes the `TritonTypes.Area` enum or a **String**; enum values like `OpportunityManagement`/`Accounts` are illustrative examples, not a required mapping. If `--area` is given, use it verbatim.
-- **`--type`** — technical classification. Default: `Backend`. `.type()` takes the `TritonTypes.Type` enum or a **String**; values like `Backend`, `BackendCall`, `DMLResult` are examples — infer what fits the code rather than forcing a mapping. (For callouts, classify as `Category.Integration` + a call type such as `BackendCall`.)
+- **`--type`** — technical classification. Default: `Backend`. `.type()` takes the `TritonTypes.Type` enum or a **String**; values like `Backend`, `BackendCall`, `DMLResult` are examples — infer what fits the code rather than forcing a mapping. (For callouts, keep the default `Apex` category, classify with a call type such as `BackendCall`, and always attach `.integrationPayload(req, res)`.)
 - **`--deploy`** — flag; if present, deploy after instrumentation. Otherwise ask at the end.
 
 ## Step 2 — Read and analyze the target file (structure first)
@@ -201,7 +201,7 @@ Triton.log(
 
 ### 3e — Callout / integration logging
 
-Attach the HTTP payload with `integrationPayload(req, res)` and classify as `Category.Integration` + `Type.BackendCall`:
+Attach the HTTP payload with `integrationPayload(req, res)`, keep the default `Apex` category, and classify as `Type.BackendCall`:
 
 ```apex
 HttpResponse res;
@@ -210,7 +210,6 @@ try {
     if (res.getStatusCode() < 200 || res.getStatusCode() >= 300) {
         Triton.logNow(
             Triton.makeBuilder()
-                .category(TritonTypes.Category.Integration)
                 .type(TritonTypes.Type.BackendCall)
                 .area(TritonTypes.Area.<area>)
                 .summary('Callout failed: ' + res.getStatus())
@@ -222,7 +221,6 @@ try {
 } catch (Exception e) {
     Triton.logNow(
         Triton.makeBuilder()
-            .category(TritonTypes.Category.Integration)
             .area(TritonTypes.Area.<area>)
             .exception(e)
             .integrationPayload(req, res)
@@ -363,5 +361,5 @@ Parse the JSON output:
 - Never add logging inside test methods or `@isTest` classes.
 - Never flush inside for/while loops.
 - Do not manually add stack trace, operation, or limit info — `Triton.log()` adds them automatically.
-- **Area gets special attention**: infer it from the code and reuse the Area already used by related code so a feature's logs group together. Area/Type enum values are examples, not a required mapping — use `.area(String)`/`.type(String)` when they fit better. Category should stay standard (`Apex`, or `Integration` for callouts).
+- **Area gets special attention**: infer it from the code and reuse the Area already used by related code so a feature's logs group together. Area/Type enum values are examples, not a required mapping — use `.area(String)`/`.type(String)` when they fit better. Category should stay standard (`Apex` — including callouts, which are distinguished by `integrationPayload` + a call type, not by category).
 - Never log PII (SSN, password, card numbers) — if detected, add `// TODO: sanitize before logging` and use a placeholder summary.

--- a/agent-skills/migrate-to-2.0.md
+++ b/agent-skills/migrate-to-2.0.md
@@ -49,6 +49,8 @@ Rewrite each call using this mapping (the `.instance` drops away; positional arg
 | `Triton.instance.resumeTransaction(id)` | `Triton.resumeTransaction(id)` |
 | `Triton.instance.stopTransaction()` | `Triton.stopTransaction()` |
 
+> **Note on `addIntegrationError`:** the legacy call wrote `Category = 'Integration'`; the 2.0 form intentionally lands as `Apex` — the Integration category is deprecated, and post-processing payload preservation is triggered by the `integrationPayload` itself, not by category.
+
 Transaction/template methods are safe renames. The **logging** methods change shape — and hide the one gotcha.
 
 ## Step 4 — The publishing gotcha (NEVER auto-decide)

--- a/docs/superpowers/plans/2026-08-17-LOG-2927-deprecate-integration-category.md
+++ b/docs/superpowers/plans/2026-08-17-LOG-2927-deprecate-integration-category.md
@@ -1,0 +1,394 @@
+# LOG-2927 — Deprecate Integration Category Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the `TritonTypes.Category.Integration` enum member and fold integration logging into the Apex category (payload via `integrationPayload`), with sanctioned context-mapping of the `'Integration'` string in the Flow/LWC bridges.
+
+**Architecture:** Three small, independent surfaces: (1) bridge guards in `TritonFlow`/`TritonLwc` that accept the deprecated `'Integration'` string case-insensitively and keep the context default category without the invalid-category note; (2) test rewrites in `TritonTest` so integration-payload coverage asserts Apex category + populated `pharos__Stacktrace_Parse_Result__c`; (3) the enum removal plus doc-comment and skill-guidance updates. The payload mechanism (`integrationPayload`, `TritonHelper.toJson`, `IntegrationWrapper`) is untouched.
+
+**Tech Stack:** Salesforce Apex (no namespace, depends on managed package `Pharos@2.275.0.3`), qa42 persistent org via `/Users/glyuk/dev/triton/.claude/ship-org.sh` wrapper only, Jest for LWC (unaffected — sanity run only).
+
+**Spec:** `docs/superpowers/specs/2026-08-17-LOG-2927-deprecate-integration-category-design.md`
+
+## Global Constraints
+
+- Base branch `origin/release/2.0`; work happens in worktree `/Users/glyuk/dev/triton-wt-LOG-2927` on branch `feature/LOG-2927`. Never push, never create PRs; commit locally only.
+- Org access ONLY via `/Users/glyuk/dev/triton/.claude/ship-org.sh` (absolute path; works from the worktree): `deploy`, `test <ClassName>`, `test` (full), `status`. Direct `sf` denied.
+- Keep the diff surgically minimal in `TritonTest.cls`, `TritonHelper.cls`, `TritonFlow.cls` to minimize conflicts with PR #48 (feature/LOG-2921, not yet in base).
+- RELEASE-ORDERING (informational, no code impact here): Logger PR #3416 must reach subscribers no later than this Triton change.
+- Known non-blocking full-suite failure on qa42: org-resident stale `LogTest.test_save_component_log`.
+- `integrationPayload` / `TritonHelper.toJson` / `IntegrationWrapper` are KEPT — do not touch TritonBuilder.cls.
+- No `Co-Authored-By` trailers in commit messages.
+
+---
+
+### Task 1: Flow bridge — sanctioned `'Integration'` → Flow mapping
+
+**Files:**
+- Modify: `force-app/main/default/classes/TritonFlow.cls:86-93`
+- Test: `force-app/main/default/classes/TritonFlowTest.cls` (new test after `test_flow_wrong_category`, ends line 174)
+
+**Interfaces:**
+- Consumes: `TritonTestFactory.makeFlowLog(String)`, `.resetFlowState()`, `.flushCachedFlowLogs()`, `.queryLogs()` (selects `pharos__Category__c`, `pharos__Details__c`), `TritonFlow.log(List<TritonFlow.FlowLog>)`.
+- Produces: `TritonFlow` resolves category `'Integration'`/`'integration'` to `TritonTypes.Category.Flow` with no `INVALID_CATEGORY` note in details. Behavior for all other category strings unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Insert into `TritonFlowTest.cls` immediately after the closing brace of `test_flow_wrong_category` (line 174), before the `test_flow_create_issue` doc comment:
+
+```apex
+    /**
+     * Deprecated 'Integration' category is a sanctioned input (LOG-2927):
+     * mapped case-insensitively to the Flow context category,
+     * without the invalid-category note.
+     */
+    @IsTest
+    private static void test_flow_integration_category_maps_to_flow() {
+        TritonTestFactory.assertNoLogs();
+        TritonTestFactory.resetFlowState();
+
+        Test.startTest();
+        TritonFlow.FlowLog flowLog = TritonTestFactory.makeFlowLog('integration exact case');
+        flowLog.category = 'Integration';
+        TritonFlow.FlowLog flowLogLowercase = TritonTestFactory.makeFlowLog('integration lower case');
+        flowLogLowercase.category = 'integration';
+        TritonFlow.log(new List<TritonFlow.FlowLog>{ flowLog, flowLogLowercase });
+        TritonTestFactory.flushCachedFlowLogs();
+        Test.stopTest();
+
+        List<pharos__Log__c> logs = TritonTestFactory.queryLogs();
+        System.assertEquals(2, logs.size(), 'Expected both flow logs to be created');
+        for (pharos__Log__c log : logs) {
+            System.assertEquals(TritonTypes.Category.Flow.name(), log.pharos__Category__c,
+                'Deprecated Integration category should map to Flow, but was: ' + log.pharos__Category__c);
+            System.assert(log.pharos__Details__c == null || !log.pharos__Details__c.contains('Unable to locate category'),
+                'Sanctioned Integration mapping must not append the invalid-category note');
+        }
+    }
+```
+
+- [ ] **Step 2: Deploy and run test to verify it fails**
+
+Run: `/Users/glyuk/dev/triton/.claude/ship-org.sh deploy` then `/Users/glyuk/dev/triton/.claude/ship-org.sh test TritonFlowTest`
+Expected: `test_flow_integration_category_maps_to_flow` FAILS — the `'Integration'` log resolves via `Category.valueOf` to `Integration` (enum member still exists at this point), and the `'integration'` log takes the invalid path and appends the note. All other TritonFlowTest tests PASS.
+
+- [ ] **Step 3: Implement the guard in TritonFlow.cls**
+
+Replace lines 86–93 (`TritonTypes.Category category = ...` through the closing `}` of its catch):
+
+```apex
+        TritonTypes.Category category = TritonTypes.Category.Flow;
+        // LOG-2927: deprecated 'Integration' category is accepted and maps to the context default (Flow)
+        if (!'Integration'.equalsIgnoreCase(flowLog.category)) {
+            try {
+                category = TritonTypes.Category.valueOf(flowLog.category);
+            } catch (Exception e) {
+                if(String.isNotBlank(flowLog.category)) {
+                    flowDetails += Triton.SPACE_SEP + TritonHelper.formatMessage(INVALID_CATEGORY, flowLog.category);
+                }
+            }
+        }
+```
+
+(Note: `'Integration'.equalsIgnoreCase(null)` is `false`, so null/blank categories keep their existing path.)
+
+- [ ] **Step 4: Deploy and run test to verify it passes**
+
+Run: `/Users/glyuk/dev/triton/.claude/ship-org.sh deploy` then `/Users/glyuk/dev/triton/.claude/ship-org.sh test TritonFlowTest`
+Expected: ALL TritonFlowTest tests PASS (including existing `test_flow_wrong_category` and the invalid-category branch of `test_flow`, which use `'InvalidCategory'`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/glyuk/dev/triton-wt-LOG-2927
+git add force-app/main/default/classes/TritonFlow.cls force-app/main/default/classes/TritonFlowTest.cls
+git commit -m "LOG-2927: Flow bridge maps deprecated 'Integration' category to Flow (case-insensitive, no invalid-category note)"
+```
+
+---
+
+### Task 2: LWC bridge — sanctioned `'Integration'` → LWC mapping
+
+**Files:**
+- Modify: `force-app/main/default/classes/TritonLwc.cls:81-86`
+- Test: `force-app/main/default/classes/TritonTest.cls` (new test after `test_save_component_log`, ends line 714)
+
+**Interfaces:**
+- Consumes: `TritonLwc.ComponentLog` / `TritonLwc.Component` shapes, `TritonLwc.saveComponentLogs(List<ComponentLog>)`, `TritonTestFactory.assertNoLogs()`.
+- Produces: `TritonLwc` resolves category `'Integration'`/`'integration'` to `TritonTypes.Category.LWC` with no "Invalid Log Category" note in details. All other category strings unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Insert into `TritonTest.cls` immediately after the closing brace of `test_save_component_log` (line 714), before `test_lwc_runtime_info`:
+
+```apex
+    /**
+     * Deprecated 'Integration' category is a sanctioned input (LOG-2927):
+     * mapped case-insensitively to the LWC context category,
+     * without the invalid-category note.
+     */
+    @IsTest
+    private static void test_save_component_log_integration_category_maps_to_lwc() {
+        TritonTestFactory.assertNoLogs();
+
+        Test.startTest();
+        List<TritonLwc.ComponentLog> componentLogs = new List<TritonLwc.ComponentLog>();
+        for (String categoryValue : new List<String>{'Integration', 'integration'}) {
+            TritonLwc.ComponentLog componentLog = new TritonLwc.ComponentLog();
+            componentLog.category = categoryValue;
+            componentLog.type = 'test type';
+            componentLog.area = TritonTypes.Area.LWC.name();
+            componentLog.level = TritonTypes.Level.ERROR.name();
+            componentLog.summary = 'integration category mapping: ' + categoryValue;
+            componentLog.details = 'test details';
+            TritonLwc.Component component = new TritonLwc.Component();
+            component.name = 'TestComponent';
+            component.function = 'testFunction';
+            componentLog.componentInfo = component;
+            componentLogs.add(componentLog);
+        }
+        TritonLwc.saveComponentLogs(componentLogs);
+        Test.stopTest();
+
+        List<pharos__Log__c> logs = [SELECT Id, pharos__Category__c, pharos__Details__c FROM pharos__Log__c];
+        System.assertEquals(2, logs.size(), 'Expected both component logs to be created');
+        for (pharos__Log__c log : logs) {
+            System.assertEquals(TritonTypes.Category.LWC.name(), log.pharos__Category__c,
+                'Deprecated Integration category should map to LWC, but was: ' + log.pharos__Category__c);
+            System.assert(log.pharos__Details__c == null || !log.pharos__Details__c.contains('Invalid Log Category'),
+                'Sanctioned Integration mapping must not append the invalid-category note');
+        }
+    }
+```
+
+- [ ] **Step 2: Deploy and run test to verify it fails**
+
+Run: `/Users/glyuk/dev/triton/.claude/ship-org.sh deploy` then `/Users/glyuk/dev/triton/.claude/ship-org.sh test TritonTest`
+Expected: `test_save_component_log_integration_category_maps_to_lwc` FAILS (`'Integration'` resolves to the still-present enum member; `'integration'` takes the invalid path and appends the note). Other TritonTest tests PASS.
+
+- [ ] **Step 3: Implement the guard in TritonLwc.cls**
+
+Replace lines 81–86 (the `try { category = ... }` block):
+
+```apex
+            // LOG-2927: deprecated 'Integration' category is accepted and maps to the context default (LWC)
+            if (!'Integration'.equalsIgnoreCase(componentLog.category)) {
+                try {
+                    category = TritonTypes.Category.valueOf(componentLog.category);
+                } catch(Exception e) {
+                    //invalid category
+                    details += Triton.SPACE_SEP + TritonHelper.formatMessage('Invalid Log Category: {0}. Default LWC category will be used.', componentLog.category);
+                }
+            }
+```
+
+- [ ] **Step 4: Deploy and run test to verify it passes**
+
+Run: `/Users/glyuk/dev/triton/.claude/ship-org.sh deploy` then `/Users/glyuk/dev/triton/.claude/ship-org.sh test TritonTest`
+Expected: new test PASSES; the existing invalid-category assertion (TritonTest:899, uses a non-Integration bad string) still PASSES.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/glyuk/dev/triton-wt-LOG-2927
+git add force-app/main/default/classes/TritonLwc.cls force-app/main/default/classes/TritonTest.cls
+git commit -m "LOG-2927: LWC bridge maps deprecated 'Integration' category to LWC (case-insensitive, no invalid-category note)"
+```
+
+---
+
+### Task 3: Rewrite TritonTest integration-payload coverage onto Apex category
+
+**Files:**
+- Modify: `force-app/main/default/classes/TritonTest.cls` (lines 14–23, 660, 674–680, 1133, 1136, 1822, 1840, 1860–1868, 2383–2387, 2401, 2411 — pre-Task-2 numbering; Task 2 inserted ~35 lines after line 714, so locations from 1121 onward shift by that amount; locate by content, not line number)
+
+**Interfaces:**
+- Consumes: builder default-category behavior (`TritonBuilder.build()` defaults `pharos__Category__c` to `Apex` when no category set).
+- Produces: helper renamed to `assertCreatedIntegrationPayloadLogs()`; zero references to `TritonTypes.Category.Integration` remain in `TritonTest.cls` (precondition for Task 4's enum removal).
+
+- [ ] **Step 1: Rewrite the assertion helper (lines 14–23)**
+
+Replace `assertCreatedIntegrationLog` entirely with:
+
+```apex
+    private static void assertCreatedIntegrationPayloadLogs() {
+        List<pharos__Log__c> logs = [SELECT Id, pharos__Category__c, pharos__Hash__c, pharos__Summary__c, pharos__Stacktrace_Parse_Result__c FROM pharos__Log__c ORDER BY CreatedDate];
+        System.assertEquals(2, logs.size(), 'Expected exactly 2 logs, found: ' + logs.size());
+        for(Integer i = 0; i < logs.size(); i++) {
+            System.assertEquals(TritonTypes.Category.Apex.name(), logs.get(i).pharos__Category__c,
+                'Log ' + i + ' (' + logs.get(i).pharos__Summary__c + ') should be Apex category, but was: ' + logs.get(i).pharos__Category__c);
+            System.assertNotEquals(null, logs.get(i).pharos__Stacktrace_Parse_Result__c,
+                'Log ' + i + ' should carry the integration payload');
+        }
+        System.assertNotEquals(null, logs.get(0).pharos__Hash__c);
+        System.assertNotEquals(null, logs.get(1).pharos__Hash__c);
+    }
+```
+
+Update its single call site in `test_sync_integration_from_exception` (line 660): `assertCreatedIntegrationLog();` → `assertCreatedIntegrationPayloadLogs();`
+
+- [ ] **Step 2: Drop explicit Integration category from emitting helpers/tests**
+
+1. `test_integration_error_sync` (~line 674): remove `.category(TritonTypes.Category.Integration)` from the builder chain, and replace the query + assertions (~lines 677–680) with:
+
+```apex
+        List<pharos__Log__c> logs = [SELECT Id, pharos__Summary__c, pharos__Hash__c, pharos__Category__c, pharos__Stacktrace_Parse_Result__c FROM pharos__Log__c];
+        System.assertEquals(1, logs.size());
+        System.assertEquals('test summary', logs.get(0).pharos__Summary__c);
+        System.assertEquals(TritonTypes.Category.Apex.name(), logs.get(0).pharos__Category__c, 'Integration payload log should default to Apex category');
+        System.assertNotEquals(null, logs.get(0).pharos__Stacktrace_Parse_Result__c, 'Integration payload should be preserved');
+        System.assertNotEquals(null, logs.get(0).pharos__Hash__c);
+```
+
+2. `testHttpRequest()` helper (~lines 1133 and 1136): remove `.category(TritonTypes.Category.Integration)` from both `Triton.logNow(...)` builder chains (leave everything else identical).
+
+3. `test_event_and_integration_error_variations` (~lines 1822 and 1840): remove `.category(TritonTypes.Category.Integration)` from both builders. Replace the verification loop (~lines 1860–1868) with:
+
+```apex
+        System.assertEquals(3, logs.size(), 'Should have created event and integration error logs');
+
+        Integer payloadLogs = 0;
+        for(pharos__Log__c log : logs) {
+            if(log.pharos__Stacktrace_Parse_Result__c != null) {
+                payloadLogs++;
+                System.assertEquals(TritonTypes.Category.Apex.name(), log.pharos__Category__c,
+                    'Integration payload log should default to Apex category');
+            }
+        }
+        System.assertEquals(2, payloadLogs, 'Both integration error logs should carry parsed request/response data');
+```
+
+- [ ] **Step 3: Substitute Category.Event in the two builder-behavior tests**
+
+1. `test_default_category_not_overridden` (~lines 2383–2387): change `.category(TritonTypes.Category.Integration)` → `.category(TritonTypes.Category.Event)` and the assertion to `System.assertEquals(TritonTypes.Category.Event.name(), log.pharos__Category__c, 'Explicit category should not be overridden');`
+
+2. `test_builder_clone` (~line 2401): change `.category(TritonTypes.Category.Integration)` → `.category(TritonTypes.Category.Event)`; assertion (~line 2411): `TritonTypes.Category.Integration.name()` → `TritonTypes.Category.Event.name()`.
+
+- [ ] **Step 4: Verify zero enum references remain, deploy, run**
+
+Run: `grep -n "Category.Integration" /Users/glyuk/dev/triton-wt-LOG-2927/force-app/main/default/classes/TritonTest.cls` — expected: no matches.
+Run: `/Users/glyuk/dev/triton/.claude/ship-org.sh deploy` then `/Users/glyuk/dev/triton/.claude/ship-org.sh test TritonTest`
+Expected: ALL PASS. (These rewrites are green even before the enum removal — dropping `.category(...)` means the logs already default to Apex; the compile-breaking dependency on the enum is what this task removes ahead of Task 4.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/glyuk/dev/triton-wt-LOG-2927
+git add force-app/main/default/classes/TritonTest.cls
+git commit -m "LOG-2927: rewrite integration-payload test coverage onto Apex-category logs"
+```
+
+---
+
+### Task 4: Remove the Category.Integration enum member + doc comments
+
+**Files:**
+- Modify: `force-app/main/default/classes/TritonTypes.cls:15,53-54`
+- Modify: `force-app/main/default/classes/TritonHelper.cls:423`
+
+**Interfaces:**
+- Consumes: Task 3's guarantee that no Apex in the repo references `Category.Integration` (grep-verified).
+- Produces: `TritonTypes.Category` = `{Apex, Flow, LWC, Aura, Warning, Event, Debug}`.
+
+- [ ] **Step 1: Remove the enum member and update doc comments**
+
+`TritonTypes.cls` — the Category enum (lines 46–55) becomes:
+
+```apex
+    public enum Category {
+        Apex,
+        Flow,
+        LWC,
+        Aura,
+        Warning,
+        Event,
+        Debug
+    }
+```
+
+`TritonTypes.cls:15`: ` * - Category enum: Provides high-level classification of log entries (e.g., Apex, Flow, Integration)` → ` * - Category enum: Provides high-level classification of log entries (e.g., Apex, Flow, LWC)`
+
+`TritonHelper.cls:423`: `         * Only applicable to Apex and Integration logs` → `         * Only applicable to Apex logs`
+
+- [ ] **Step 2: Verify no remaining references, deploy, run affected suites**
+
+Run: `grep -rn "Category.Integration" /Users/glyuk/dev/triton-wt-LOG-2927/force-app/` — expected: no matches.
+Run: `/Users/glyuk/dev/triton/.claude/ship-org.sh deploy`
+Expected: deploy succeeds (compile proves nothing references the removed member).
+Run: `/Users/glyuk/dev/triton/.claude/ship-org.sh test TritonTest` and `/Users/glyuk/dev/triton/.claude/ship-org.sh test TritonFlowTest`
+Expected: ALL PASS — including Task 1/2's bridge tests, which now exercise the post-removal path (`'Integration'` no longer resolvable via `valueOf`, handled by the guards).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/glyuk/dev/triton-wt-LOG-2927
+git add force-app/main/default/classes/TritonTypes.cls force-app/main/default/classes/TritonHelper.cls
+git commit -m "LOG-2927: remove deprecated TritonTypes.Category.Integration enum member"
+```
+
+---
+
+### Task 5: Update skill guidance (instrument-apex.md, migrate-to-2.0.md)
+
+**Files:**
+- Modify: `agent-skills/instrument-apex.md:40,204,213,225,366`
+- Modify: `agent-skills/migrate-to-2.0.md` (note after the mapping table, ~line 51)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (docs only, no deploy needed).
+- Produces: skill guidance that no longer instructs `Category.Integration`.
+
+- [ ] **Step 1: Edit instrument-apex.md**
+
+1. Line 40: `(For callouts, classify as `` `Category.Integration` `` + a call type such as `` `BackendCall` ``.)` → `(For callouts, keep the default `` `Apex` `` category, classify with a call type such as `` `BackendCall` ``, and always attach `` `.integrationPayload(req, res)` ``.)`
+2. Line 204: `Attach the HTTP payload with `` `integrationPayload(req, res)` `` and classify as `` `Category.Integration` `` + `` `Type.BackendCall` ``:` → `Attach the HTTP payload with `` `integrationPayload(req, res)` ``, keep the default `` `Apex` `` category, and classify as `` `Type.BackendCall` ``:`
+3. Delete the line `                .category(TritonTypes.Category.Integration)` from the first code example (line 213).
+4. Delete the line `            .category(TritonTypes.Category.Integration)` from the catch-block example (line 225).
+5. Line 366: `Category should stay standard (`` `Apex` ``, or `` `Integration` `` for callouts).` → `Category should stay standard (`` `Apex` `` — including callouts, which are distinguished by `` `integrationPayload` `` + a call type, not by category).`
+
+- [ ] **Step 2: Add the note to migrate-to-2.0.md**
+
+Insert after the mapping table (after line 50's `stopTransaction` row, before line 52's "Transaction/template methods..." paragraph):
+
+```markdown
+
+> **Note on `addIntegrationError`:** the legacy call wrote `Category = 'Integration'`; the 2.0 form intentionally lands as `Apex` — the Integration category is deprecated, and post-processing payload preservation is triggered by the `integrationPayload` itself, not by category.
+```
+
+- [ ] **Step 3: Verify no stale guidance remains**
+
+Run: `grep -rn "Category.Integration" /Users/glyuk/dev/triton-wt-LOG-2927/agent-skills/` — expected: no matches.
+Run: `grep -rni "integration" /Users/glyuk/dev/triton-wt-LOG-2927/agent-skills/instrument-apex.md` — expected: only `integrationPayload` mentions and the reworded lines.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/glyuk/dev/triton-wt-LOG-2927
+git add agent-skills/instrument-apex.md agent-skills/migrate-to-2.0.md
+git commit -m "LOG-2927: skill guidance — callouts keep default Apex category with integrationPayload"
+```
+
+---
+
+### Task 6: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full Apex suite on qa42**
+
+Run: `/Users/glyuk/dev/triton/.claude/ship-org.sh test`
+Expected: all tests PASS except the documented non-blocking org-resident stale `LogTest.test_save_component_log` failure. Record exact pass/fail counts for the DONE message.
+
+- [ ] **Step 2: Jest sanity**
+
+Run: `npm test` (from the worktree root)
+Expected: PASS (no LWC changes in this ticket).
+
+- [ ] **Step 3: Final review of the branch diff**
+
+Run: `git -C /Users/glyuk/dev/triton-wt-LOG-2927 diff origin/release/2.0...HEAD --stat` and `git -C /Users/glyuk/dev/triton-wt-LOG-2927 status --short`
+Expected: only the spec/plan docs, TritonFlow.cls, TritonFlowTest.cls, TritonLwc.cls, TritonTest.cls, TritonTypes.cls, TritonHelper.cls, instrument-apex.md, migrate-to-2.0.md; clean tree, no featureParameters mutations (none were made — no `param` toggles used).
+
+- [ ] **Step 4: Send DONE**
+
+Send `DONE LOG-2927 triton: ...` to atlas with files changed, full test-run summary (counts, noting the documented non-blocking failure), and commits on branch.

--- a/docs/superpowers/specs/2026-08-17-LOG-2927-deprecate-integration-category-design.md
+++ b/docs/superpowers/specs/2026-08-17-LOG-2927-deprecate-integration-category-design.md
@@ -1,0 +1,111 @@
+# LOG-2927 — Deprecate the Integration log Category (fold into Apex)
+
+- **Ticket:** https://goldenratio.atlassian.net/browse/LOG-2927
+- **Base branch:** `origin/release/2.0` (branch `feature/LOG-2927`)
+- **Scope:** triton repo only. The Logger-side change is already implemented, reviewed, and pushed (https://github.com/grsys/Logger/pull/3416): post-processing payload preservation is now payload-triggered (request+response shape detection), so Apex-category logs carrying integration payloads keep their payloads. The legacy Integration branch is retained in Logger for old producers.
+
+## ⚠️ RELEASE-ORDERING CONSTRAINT (read first)
+
+**The Logger release containing PR #3416 must reach subscriber orgs NO LATER than the Triton release containing this change.** On older Logger versions, post-processing payload preservation still keys on `Category = 'Integration'`; Apex-category logs with integration payloads would **lose their payloads in post-processing**. Do not ship this Triton change to a subscriber population ahead of that Logger release.
+
+## Summary of change
+
+The `Integration` log Category is deprecated product-wide. Integration (callout/REST) logs become **Apex-category logs that carry an integration payload** via `integrationPayload(req, res)`. This change:
+
+1. **Removes** the `TritonTypes.Category.Integration` enum member (accepted breaking change — see below).
+2. **Keeps** the payload mechanism unchanged: `TritonBuilder.integrationPayload(HttpRequest, HttpResponse)` and `(RestRequest, RestResponse)` (TritonBuilder.cls:477, 488) and `TritonHelper.toJson`/`IntegrationWrapper` (TritonHelper.cls:286–315) are category-agnostic and remain the ongoing mechanism.
+3. **Updates** skill guidance (`agent-skills/instrument-apex.md`) — the highest-value change, since that skill is what generates new Integration-category logs in customer orgs.
+4. **Rewrites** tests so integration-payload behavior keeps full coverage on Apex-category logs.
+
+## Breaking-change statement
+
+**What breaks:** Triton is source-distributed. Any customer Apex referencing `TritonTypes.Category.Integration` fails to compile when they take this version.
+
+**Migration note (for release notes / changelog):** replace explicit `.category(TritonTypes.Category.Integration)` with no category call at all — the builder defaults to `Apex` (TritonBuilder.cls:810–815) — and attach the HTTP payload with `.integrationPayload(req, res)`. Example:
+
+```apex
+// Before
+Triton.logNow(Triton.makeBuilder()
+    .category(TritonTypes.Category.Integration)
+    .type(TritonTypes.Type.BackendCall)
+    .area(...).summary(...).integrationPayload(req, res).error());
+
+// After
+Triton.logNow(Triton.makeBuilder()
+    .type(TritonTypes.Type.BackendCall)
+    .area(...).summary(...).integrationPayload(req, res).error());
+```
+
+**Accepted behavior changes (state, don't fight):**
+
+- Former Integration-category logs now get **`apexExecutionContext` captured**: `TritonBuilder.prepareForLogging()` gates context capture on `Category == Apex` (TritonBuilder.cls:794–797), which these logs now satisfy.
+- **Flow/LWC producers passing the string `'Integration'`** as category: both bridges resolve category via `TritonTypes.Category.valueOf(...)` inside a try/catch (TritonFlow.cls:87–93, TritonLwc.cls:81–86). After the enum member is removed, `valueOf('Integration')` throws, and the log **falls back gracefully** to the default `Flow`/`LWC` category with an "Invalid Log Category" note appended to details. No log is lost. We do NOT special-case `'Integration'` → `Apex` in the bridges (minimal diff; see Open Questions).
+
+## Exact file/line changes
+
+All line numbers are against `origin/release/2.0` (998079f).
+
+### 1. `force-app/main/default/classes/TritonTypes.cls`
+- **:54** — remove the `Integration` enum member (last in the `Category` list; also remove the trailing comma on `Debug`, line 53).
+- **:15** — class doc comment `(e.g., Apex, Flow, Integration)` → `(e.g., Apex, Flow, LWC)`.
+
+### 2. `agent-skills/instrument-apex.md`
+- **:40** — `(For callouts, classify as `Category.Integration` + a call type such as `BackendCall`.)` → callouts keep the default `Apex` category; classify with a call type such as `BackendCall` and always attach `.integrationPayload(req, res)`.
+- **:204** — "Attach the HTTP payload with `integrationPayload(req, res)` and classify as `Category.Integration` + `Type.BackendCall`" → "…keep the default `Apex` category and classify as `Type.BackendCall`".
+- **:213, :225** — delete the `.category(TritonTypes.Category.Integration)` lines from both code examples (success-path status check and catch block).
+- **:366** — "Category should stay standard (`Apex`, or `Integration` for callouts)." → "Category should stay standard (`Apex` — including callouts, which are distinguished by `integrationPayload` + a call type, not by category)."
+- (`:63` mentions `integrationPayload` only — no category reference, unchanged.)
+
+### 3. `agent-skills/migrate-to-2.0.md`
+- **:43** — the mapping target for `addIntegrationError` **already** reads `Triton.error(Triton.t.area(area).exception(e).integrationPayload(request, response))` — i.e. default Apex category. No mapping change needed. **Add a short note** (below the table or as a table footnote): the legacy call wrote `Category = 'Integration'`; the 2.0 form intentionally lands as `Apex` — the Integration category is deprecated, and payload preservation is triggered by the payload itself.
+
+### 4. `force-app/main/default/classes/TritonHelper.cls`
+- **:423** — `PostProcessingControlsBuilder.stackTrace` doc comment "Only applicable to Apex and Integration logs" → "Only applicable to Apex logs". (No code change; `toJson`/`IntegrationWrapper` at :286–315 are kept as-is.)
+
+### 5. `force-app/main/default/classes/TritonTest.cls` — test rewrite plan
+
+Principle: every scenario that exercised the integration-payload pipeline keeps full coverage, now asserting **Apex category + populated `pharos__Stacktrace_Parse_Result__c`** instead of `Category = 'Integration'`. Test *method* names are kept (they describe integration-payload scenarios, still accurate); only the helper is renamed for honesty.
+
+| Location | Current | Change |
+|---|---|---|
+| :14–23 `assertCreatedIntegrationLog()` | asserts both logs have `Category = Integration` | rename to `assertCreatedIntegrationPayloadLogs()`; assert `Category = Apex` **and** `pharos__Stacktrace_Parse_Result__c != null` for both logs (add the field to the SOQL); keep the 2-log count and hash assertions |
+| :643–661 `test_sync_integration_from_exception` | calls the helper | update helper call site only |
+| :663–681 `test_integration_error_sync` | builder uses `.category(Category.Integration)` | drop the `.category(...)` call; add assertions `Category = Apex` and payload non-null (add fields to the SOQL at :677) |
+| :995–1007 (builder attribute test) | `integrationPayload` round-trip assertions | **unchanged** — category-agnostic |
+| :1121–1138 `testHttpRequest()` helper | both `logNow` builders use `.category(Category.Integration)` | drop both `.category(...)` calls |
+| :1795–1869 `test_event_and_integration_error_variations` | two builders use `.category(Category.Integration)`; assertion loop at :1863–1868 keys on `Category == 'Integration'` | drop both `.category(...)` calls; rewrite the loop to assert exactly 2 of the 3 logs are `Category = Apex` with non-null `pharos__Stacktrace_Parse_Result__c` (the Event log has none) |
+| :2380–2388 `test_default_category_not_overridden` | uses `Category.Integration` as the explicit non-default category | substitute `Category.Event` — preserves the "explicit category is not overridden by the Apex default" coverage |
+| :2398–2419 `test_builder_clone` | clones a builder with `Category.Integration`; asserts it at :2411 | substitute `Category.Event` in both places — preserves clone-preserves-category coverage |
+
+No changes to `TritonFlowTest.cls` (its only "Integration" hit is an unrelated comment at :354), `TritonTestFactory`, `Triton.cls`, `TritonFlow.cls`, `TritonLwc.cls`, `TritonBuilder.cls`, or any LWC (zero JS references to Integration).
+
+## Merge-conflict notes vs PR #48 (feature/LOG-2921, not yet in base)
+
+PR #48 modified `TritonHelper.cls`, `TritonBuilder.cls`, `TritonFlow.cls`, `TritonTest.cls`, `TritonFlowTest.cls`, `agent-skills/instrument-flows.md`. Expected interaction:
+
+- **TritonTest.cls** — PR #48 is a single ~380-line insertion hunk at old lines ~572–583. LOG-2927 edits lines 14–23, 644–681, 1121–1138, 1795–1869, 2380–2419 — no overlapping hunks; git should auto-merge. This is still the file to watch: whichever PR merges second should re-run the suite, since PR #48's added tests build logs via `makeBuilder()` and could theoretically reference the removed enum (spot-check on merge; its diff predates LOG-2927).
+- **TritonHelper.cls** — PR #48's hunks all start at line 689+; LOG-2927 touches only the :423 doc comment. No conflict.
+- **TritonBuilder.cls / TritonFlow.cls** — LOG-2927 makes **no changes** to either. No conflict.
+- **agent-skills** — PR #48 touches `instrument-flows.md` only; LOG-2927 touches `instrument-apex.md` + `migrate-to-2.0.md`. No conflict.
+- **docs/superpowers/** — both PRs add distinct new files. No conflict.
+
+## Verification plan
+
+1. **TDD order:** first rewrite the tests (they fail to compile against the removed enum, or fail asserting Apex category while Integration is still emitted), then remove the enum member and watch them pass.
+2. Deploy each increment to **qa42** via the hub-provisioned wrapper (`.claude/ship-org.sh deploy`, invoked by absolute path from the worktree).
+3. Focused loop: `test TritonTest` after the test rewrite + enum removal.
+4. Before DONE: **full Apex suite** on qa42 via the wrapper. Known non-blocking: the org-resident stale `LogTest` failure documented for this org.
+5. `npm test` (Jest) as a cheap sanity pass — no LWC files change, expected green.
+6. No feature-param toggles are needed for this change; nothing to restore.
+
+## Out of scope
+
+- Any Logger-side work (already shipped via PR #3416).
+- Special-casing the `'Integration'` string in the Flow/LWC bridges (see Open Questions).
+- Removing `integrationPayload` / `toJson` / `IntegrationWrapper` — these are the ongoing mechanism and are kept.
+
+## Open questions
+
+1. **migrate-to-2.0.md:43** already targets default-Apex + `integrationPayload` (no `.category(Integration)` on the 2.0 side). Plan is to keep the mapping unchanged and add only the explanatory note described above — confirm this satisfies the "update the mapping target" decision.
+2. **Flow/LWC `'Integration'` string fallback:** after enum removal, Flow/LWC logs passing `category='Integration'` land as `Flow`/`LWC` (not `Apex`) with an "Invalid Log Category" details note — graceful, no data loss, but the category differs from the Apex-side migration story. Default plan: accept as-is (minimal diff). Alternative: special-case `'Integration'` → `Apex` in `TritonFlow`/`TritonLwc`. Confirm the default.
+3. **`test_default_category_not_overridden` / `test_builder_clone`** will use `Category.Event` as the substitute explicit category — flag if a different member is preferred.

--- a/docs/superpowers/specs/2026-08-17-LOG-2927-deprecate-integration-category-design.md
+++ b/docs/superpowers/specs/2026-08-17-LOG-2927-deprecate-integration-category-design.md
@@ -15,7 +15,8 @@ The `Integration` log Category is deprecated product-wide. Integration (callout/
 1. **Removes** the `TritonTypes.Category.Integration` enum member (accepted breaking change — see below).
 2. **Keeps** the payload mechanism unchanged: `TritonBuilder.integrationPayload(HttpRequest, HttpResponse)` and `(RestRequest, RestResponse)` (TritonBuilder.cls:477, 488) and `TritonHelper.toJson`/`IntegrationWrapper` (TritonHelper.cls:286–315) are category-agnostic and remain the ongoing mechanism.
 3. **Updates** skill guidance (`agent-skills/instrument-apex.md`) — the highest-value change, since that skill is what generates new Integration-category logs in customer orgs.
-4. **Rewrites** tests so integration-payload behavior keeps full coverage on Apex-category logs.
+4. **Maps** the `'Integration'` category string in the Flow/LWC bridges to the emission context's own category (Flow → `Flow`, LWC → `LWC`), case-insensitively, without the invalid-category details note — sanctioned deprecation mapping, not bad input.
+5. **Rewrites** tests so integration-payload behavior keeps full coverage on Apex-category logs, plus new tests for the bridge mapping.
 
 ## Breaking-change statement
 
@@ -39,7 +40,8 @@ Triton.logNow(Triton.makeBuilder()
 **Accepted behavior changes (state, don't fight):**
 
 - Former Integration-category logs now get **`apexExecutionContext` captured**: `TritonBuilder.prepareForLogging()` gates context capture on `Category == Apex` (TritonBuilder.cls:794–797), which these logs now satisfy.
-- **Flow/LWC producers passing the string `'Integration'`** as category: both bridges resolve category via `TritonTypes.Category.valueOf(...)` inside a try/catch (TritonFlow.cls:87–93, TritonLwc.cls:81–86). After the enum member is removed, `valueOf('Integration')` throws, and the log **falls back gracefully** to the default `Flow`/`LWC` category with an "Invalid Log Category" note appended to details. No log is lost. We do NOT special-case `'Integration'` → `Apex` in the bridges (minimal diff; see Open Questions).
+
+**Sanctioned `'Integration'` string mapping in the bridges (decision from Nikita):** the string `'Integration'` remains an **accepted** input, overridden by the emission context's own category — Flow bridge → `Flow`, LWC bridge → `LWC`, Apex → `Apex`. It must NOT take the invalid-category path: no "Invalid Log Category"/"Unable to locate category" note is appended to details — this is sanctioned deprecation mapping, not bad input. Matching is **case-insensitive** (`'integration'` too, consistent with the case-insensitive matching philosophy adopted on LOG-2921). We also add **no** "deprecated category mapped to …" breadcrumb in details: the mapping is documented product-wide, details stay clean, and the invalid-category note remains reserved for genuinely bad input. The Apex context needs no code: `Category.Integration` no longer compiles after enum removal, and the builder default (`Apex`, TritonBuilder.cls:810–815) already applies when no category is set.
 
 ## Exact file/line changes
 
@@ -62,7 +64,13 @@ All line numbers are against `origin/release/2.0` (998079f).
 ### 4. `force-app/main/default/classes/TritonHelper.cls`
 - **:423** — `PostProcessingControlsBuilder.stackTrace` doc comment "Only applicable to Apex and Integration logs" → "Only applicable to Apex logs". (No code change; `toJson`/`IntegrationWrapper` at :286–315 are kept as-is.)
 
-### 5. `force-app/main/default/classes/TritonTest.cls` — test rewrite plan
+### 5. `force-app/main/default/classes/TritonFlow.cls` — sanctioned `'Integration'` mapping
+- **:86–93** — in the category-resolution block, before `Category.valueOf(...)`: if `'Integration'.equalsIgnoreCase(flowLog.category)`, keep the context default (`Category.Flow`) and **skip** both `valueOf` and the `INVALID_CATEGORY` details note (a one-line comment marks it as deprecation mapping). All other unknown strings keep the existing invalid-category path unchanged.
+
+### 6. `force-app/main/default/classes/TritonLwc.cls` — sanctioned `'Integration'` mapping
+- **:81–86** — same guard: if `'Integration'.equalsIgnoreCase(componentLog.category)`, keep the context default (`Category.LWC`), skip `valueOf` and the "Invalid Log Category" details note. All other unknown strings unchanged.
+
+### 7. `force-app/main/default/classes/TritonTest.cls` — test rewrite plan
 
 Principle: every scenario that exercised the integration-payload pipeline keeps full coverage, now asserting **Apex category + populated `pharos__Stacktrace_Parse_Result__c`** instead of `Category = 'Integration'`. Test *method* names are kept (they describe integration-payload scenarios, still accurate); only the helper is renamed for honesty.
 
@@ -77,7 +85,12 @@ Principle: every scenario that exercised the integration-payload pipeline keeps 
 | :2380–2388 `test_default_category_not_overridden` | uses `Category.Integration` as the explicit non-default category | substitute `Category.Event` — preserves the "explicit category is not overridden by the Apex default" coverage |
 | :2398–2419 `test_builder_clone` | clones a builder with `Category.Integration`; asserts it at :2411 | substitute `Category.Event` in both places — preserves clone-preserves-category coverage |
 
-No changes to `TritonFlowTest.cls` (its only "Integration" hit is an unrelated comment at :354), `TritonTestFactory`, `Triton.cls`, `TritonFlow.cls`, `TritonLwc.cls`, `TritonBuilder.cls`, or any LWC (zero JS references to Integration).
+**New tests for the sanctioned bridge mapping:**
+
+- `TritonFlowTest.cls` — new test `test_flow_integration_category_maps_to_flow`, placed after `test_flow_wrong_category` (:157–178): invoke `TritonFlow.log` with `category = 'Integration'` and a second log with `category = 'integration'` (case-insensitivity); assert both logs get `Category = Flow` and details do **not** contain `'Unable to locate category'`. (Existing `test_flow_wrong_category` and the invalid-category branch of `test_flow` (:54–65, :82) stay green unchanged — they use `'InvalidCategory'`.)
+- `TritonTest.cls` — new test `test_save_component_log_integration_category_maps_to_lwc`, placed near the existing LWC-bridge tests (~:683–910): submit a `TritonLwc.ComponentLog` with `category = 'Integration'` (plus a case-variant log); assert `Category = LWC` and details do **not** contain `'Invalid Log Category'`. (Existing invalid-category assertion at :899 uses `'test category'`-style bad input and stays unchanged.)
+
+No changes to `TritonTestFactory`, `Triton.cls`, `TritonBuilder.cls`, or any LWC (zero JS references to Integration).
 
 ## Merge-conflict notes vs PR #48 (feature/LOG-2921, not yet in base)
 
@@ -85,7 +98,10 @@ PR #48 modified `TritonHelper.cls`, `TritonBuilder.cls`, `TritonFlow.cls`, `Trit
 
 - **TritonTest.cls** — PR #48 is a single ~380-line insertion hunk at old lines ~572–583. LOG-2927 edits lines 14–23, 644–681, 1121–1138, 1795–1869, 2380–2419 — no overlapping hunks; git should auto-merge. This is still the file to watch: whichever PR merges second should re-run the suite, since PR #48's added tests build logs via `makeBuilder()` and could theoretically reference the removed enum (spot-check on merge; its diff predates LOG-2927).
 - **TritonHelper.cls** — PR #48's hunks all start at line 689+; LOG-2927 touches only the :423 doc comment. No conflict.
-- **TritonBuilder.cls / TritonFlow.cls** — LOG-2927 makes **no changes** to either. No conflict.
+- **TritonFlow.cls** — **expected conflict point.** PR #48 has a hunk at old lines ~92–97 (`@@ -92,6 +93,15 @@`), directly adjacent to LOG-2927's guard insertion in the category block at :86–93 — overlapping context makes a small textual conflict likely. Resolution is trivial: both edits are additive within the same resolution block (LOG-2927's `'Integration'` guard before `valueOf`, PR #48's insertion after it).
+- **TritonFlowTest.cls** — PR #48 is a single insertion at old line ~85; LOG-2927 adds a new test after :178. No overlap expected.
+- **TritonLwc.cls** — untouched by PR #48. No conflict.
+- **TritonBuilder.cls** — LOG-2927 makes **no changes**. No conflict.
 - **agent-skills** — PR #48 touches `instrument-flows.md` only; LOG-2927 touches `instrument-apex.md` + `migrate-to-2.0.md`. No conflict.
 - **docs/superpowers/** — both PRs add distinct new files. No conflict.
 
@@ -93,7 +109,7 @@ PR #48 modified `TritonHelper.cls`, `TritonBuilder.cls`, `TritonFlow.cls`, `Trit
 
 1. **TDD order:** first rewrite the tests (they fail to compile against the removed enum, or fail asserting Apex category while Integration is still emitted), then remove the enum member and watch them pass.
 2. Deploy each increment to **qa42** via the hub-provisioned wrapper (`.claude/ship-org.sh deploy`, invoked by absolute path from the worktree).
-3. Focused loop: `test TritonTest` after the test rewrite + enum removal.
+3. Focused loop: `test TritonTest` and `test TritonFlowTest` after the test rewrite + enum removal + bridge guards.
 4. Before DONE: **full Apex suite** on qa42 via the wrapper. Known non-blocking: the org-resident stale `LogTest` failure documented for this org.
 5. `npm test` (Jest) as a cheap sanity pass — no LWC files change, expected green.
 6. No feature-param toggles are needed for this change; nothing to restore.
@@ -101,11 +117,14 @@ PR #48 modified `TritonHelper.cls`, `TritonBuilder.cls`, `TritonFlow.cls`, `Trit
 ## Out of scope
 
 - Any Logger-side work (already shipped via PR #3416).
-- Special-casing the `'Integration'` string in the Flow/LWC bridges (see Open Questions).
 - Removing `integrationPayload` / `toJson` / `IntegrationWrapper` — these are the ongoing mechanism and are kept.
+
+## Resolved decisions (from Nikita, via hub)
+
+1. **migrate-to-2.0.md:43** — confirmed note-only: the mapping already targets default-Apex + `integrationPayload`; add the explanatory note, no mapping change.
+2. **`'Integration'` string in the bridges** — accepted input, overridden by the emission context's own category: Flow → `Flow`, LWC → `LWC`, Apex → `Apex` (covered by enum removal + builder default). Case-insensitive. Not the invalid-category path — no "Invalid Log Category" note. (Breadcrumb note in details was left to implementer discretion; decision: none — see the sanctioned-mapping section.)
+3. **`Category.Event`** confirmed as the substitute explicit category in `test_default_category_not_overridden` and `test_builder_clone`.
 
 ## Open questions
 
-1. **migrate-to-2.0.md:43** already targets default-Apex + `integrationPayload` (no `.category(Integration)` on the 2.0 side). Plan is to keep the mapping unchanged and add only the explanatory note described above — confirm this satisfies the "update the mapping target" decision.
-2. **Flow/LWC `'Integration'` string fallback:** after enum removal, Flow/LWC logs passing `category='Integration'` land as `Flow`/`LWC` (not `Apex`) with an "Invalid Log Category" details note — graceful, no data loss, but the category differs from the Apex-side migration story. Default plan: accept as-is (minimal diff). Alternative: special-case `'Integration'` → `Apex` in `TritonFlow`/`TritonLwc`. Confirm the default.
-3. **`test_default_category_not_overridden` / `test_builder_clone`** will use `Category.Event` as the substitute explicit category — flag if a different member is preferred.
+None.

--- a/force-app/main/default/classes/TritonFlow.cls
+++ b/force-app/main/default/classes/TritonFlow.cls
@@ -84,11 +84,14 @@ global with sharing class TritonFlow {
         }
         
         TritonTypes.Category category = TritonTypes.Category.Flow;
-        try {
-            category = TritonTypes.Category.valueOf(flowLog.category);
-        } catch (Exception e) {
-            if(String.isNotBlank(flowLog.category)) {
-                flowDetails += Triton.SPACE_SEP + TritonHelper.formatMessage(INVALID_CATEGORY, flowLog.category);
+        // LOG-2927: deprecated 'Integration' category is accepted and maps to the context default (Flow)
+        if (!'Integration'.equalsIgnoreCase(flowLog.category)) {
+            try {
+                category = TritonTypes.Category.valueOf(flowLog.category);
+            } catch (Exception e) {
+                if(String.isNotBlank(flowLog.category)) {
+                    flowDetails += Triton.SPACE_SEP + TritonHelper.formatMessage(INVALID_CATEGORY, flowLog.category);
+                }
             }
         }
         

--- a/force-app/main/default/classes/TritonFlowTest.cls
+++ b/force-app/main/default/classes/TritonFlowTest.cls
@@ -174,6 +174,35 @@ private class TritonFlowTest {
     }
 
     /**
+     * Deprecated 'Integration' category is a sanctioned input (LOG-2927):
+     * mapped case-insensitively to the Flow context category,
+     * without the invalid-category note.
+     */
+    @IsTest
+    private static void test_flow_integration_category_maps_to_flow() {
+        TritonTestFactory.assertNoLogs();
+        TritonTestFactory.resetFlowState();
+
+        Test.startTest();
+        TritonFlow.FlowLog flowLog = TritonTestFactory.makeFlowLog('integration exact case');
+        flowLog.category = 'Integration';
+        TritonFlow.FlowLog flowLogLowercase = TritonTestFactory.makeFlowLog('integration lower case');
+        flowLogLowercase.category = 'integration';
+        TritonFlow.log(new List<TritonFlow.FlowLog>{ flowLog, flowLogLowercase });
+        TritonTestFactory.flushCachedFlowLogs();
+        Test.stopTest();
+
+        List<pharos__Log__c> logs = TritonTestFactory.queryLogs();
+        System.assertEquals(2, logs.size(), 'Expected both flow logs to be created');
+        for (pharos__Log__c log : logs) {
+            System.assertEquals(TritonTypes.Category.Flow.name(), log.pharos__Category__c,
+                'Deprecated Integration category should map to Flow, but was: ' + log.pharos__Category__c);
+            System.assert(log.pharos__Details__c == null || !log.pharos__Details__c.contains('Unable to locate category'),
+                'Sanctioned Integration mapping must not append the invalid-category note');
+        }
+    }
+
+    /**
      * ERROR level via processFlowLog creates an issue (Do_Not_Create_Issue__c = false).
      */
     @IsTest

--- a/force-app/main/default/classes/TritonHelper.cls
+++ b/force-app/main/default/classes/TritonHelper.cls
@@ -420,7 +420,7 @@ public with sharing class TritonHelper {
 
         /**
          * Controls whether stack trace is enhanced by Pharos
-         * Only applicable to Apex and Integration logs
+         * Only applicable to Apex logs
          */
         public PostProcessingControlsBuilder stackTrace(Boolean value) {
             controls.put(STACK_TRACE_KEY, value);

--- a/force-app/main/default/classes/TritonLwc.cls
+++ b/force-app/main/default/classes/TritonLwc.cls
@@ -78,11 +78,14 @@ global with sharing class TritonLwc {
                 relatedIds = validIds;
             }
 
-            try {
-                category = TritonTypes.Category.valueOf(componentLog.category);
-            } catch(Exception e) {
-                //invalid category
-                details += Triton.SPACE_SEP + TritonHelper.formatMessage('Invalid Log Category: {0}. Default LWC category will be used.', componentLog.category);
+            // LOG-2927: deprecated 'Integration' category is accepted and maps to the context default (LWC)
+            if (!'Integration'.equalsIgnoreCase(componentLog.category)) {
+                try {
+                    category = TritonTypes.Category.valueOf(componentLog.category);
+                } catch(Exception e) {
+                    //invalid category
+                    details += Triton.SPACE_SEP + TritonHelper.formatMessage('Invalid Log Category: {0}. Default LWC category will be used.', componentLog.category);
+                }
             }
 
             String areaStr = String.isNotBlank(componentLog.area) ? componentLog.area : componentLog.componentInfo.name;

--- a/force-app/main/default/classes/TritonTest.cls
+++ b/force-app/main/default/classes/TritonTest.cls
@@ -11,12 +11,14 @@
 @IsTest
 private class TritonTest {
 
-    private static void assertCreatedIntegrationLog() {
-        List<pharos__Log__c> logs = [SELECT Id, pharos__Category__c, pharos__Hash__c, pharos__Summary__c FROM pharos__Log__c ORDER BY CreatedDate];
+    private static void assertCreatedIntegrationPayloadLogs() {
+        List<pharos__Log__c> logs = [SELECT Id, pharos__Category__c, pharos__Hash__c, pharos__Summary__c, pharos__Stacktrace_Parse_Result__c FROM pharos__Log__c ORDER BY CreatedDate];
         System.assertEquals(2, logs.size(), 'Expected exactly 2 logs, found: ' + logs.size());
         for(Integer i = 0; i < logs.size(); i++) {
-            System.assertEquals(TritonTypes.Category.Integration.name(), logs.get(i).pharos__Category__c,
-                'Log ' + i + ' (' + logs.get(i).pharos__Summary__c + ') should be Integration category, but was: ' + logs.get(i).pharos__Category__c);
+            System.assertEquals(TritonTypes.Category.Apex.name(), logs.get(i).pharos__Category__c,
+                'Log ' + i + ' (' + logs.get(i).pharos__Summary__c + ') should be Apex category, but was: ' + logs.get(i).pharos__Category__c);
+            System.assertNotEquals(null, logs.get(i).pharos__Stacktrace_Parse_Result__c,
+                'Log ' + i + ' should carry the integration payload');
         }
         System.assertNotEquals(null, logs.get(0).pharos__Hash__c);
         System.assertNotEquals(null, logs.get(1).pharos__Hash__c);
@@ -657,7 +659,7 @@ private class TritonTest {
         testHttpRequest();
         Test.stopTest();
 
-        assertCreatedIntegrationLog();
+        assertCreatedIntegrationPayloadLogs();
     }
 
     @IsTest
@@ -671,12 +673,14 @@ private class TritonTest {
         req.httpMethod = 'GET';
         RestContext.request = req;
         RestContext.response = res;
-        Triton.logNow(Triton.makeBuilder().category(TritonTypes.Category.Integration).type(TritonTypes.Type.Backend).area(TritonTypes.Area.Community).summary('test summary').details('test details').integrationPayload(req, res).error());
+        Triton.logNow(Triton.makeBuilder().type(TritonTypes.Type.Backend).area(TritonTypes.Area.Community).summary('test summary').details('test details').integrationPayload(req, res).error());
         Test.stopTest();
 
-        List<pharos__Log__c> logs = [SELECT Id, pharos__Summary__c, pharos__Hash__c FROM pharos__Log__c];
+        List<pharos__Log__c> logs = [SELECT Id, pharos__Summary__c, pharos__Hash__c, pharos__Category__c, pharos__Stacktrace_Parse_Result__c FROM pharos__Log__c];
         System.assertEquals(1, logs.size());
         System.assertEquals('test summary', logs.get(0).pharos__Summary__c);
+        System.assertEquals(TritonTypes.Category.Apex.name(), logs.get(0).pharos__Category__c, 'Integration payload log should default to Apex category');
+        System.assertNotEquals(null, logs.get(0).pharos__Stacktrace_Parse_Result__c, 'Integration payload should be preserved');
         System.assertNotEquals(null, logs.get(0).pharos__Hash__c);
     }
 
@@ -1168,10 +1172,10 @@ private class TritonTest {
         try {
             res = h.send(req);
             if (res.getStatusCode() != 200 || res.getStatusCode() != 201) {
-                Triton.logNow(Triton.makeBuilder().category(TritonTypes.Category.Integration).type(TritonTypes.Type.Backend).area(TritonTypes.Area.Community).summary('test integration').details('test error details').integrationPayload(req, res).error());
+                Triton.logNow(Triton.makeBuilder().type(TritonTypes.Type.Backend).area(TritonTypes.Area.Community).summary('test integration').details('test error details').integrationPayload(req, res).error());
             }
         } catch (Exception e) {
-            Triton.logNow(Triton.makeBuilder().category(TritonTypes.Category.Integration).area(TritonTypes.Area.Community).exception(e).integrationPayload(req, res));
+            Triton.logNow(Triton.makeBuilder().area(TritonTypes.Area.Community).exception(e).integrationPayload(req, res));
         }
     }
 
@@ -1857,7 +1861,6 @@ private class TritonTest {
         } catch(Exception e) {
             Triton.logNow(
                 Triton.makeBuilder()
-                    .category(TritonTypes.Category.Integration)
                     .area(TritonTypes.Area.Community)
                     .exception(e)
                     .integrationPayload(restReq, restRes)
@@ -1875,7 +1878,6 @@ private class TritonTest {
 
         Triton.logNow(
             Triton.makeBuilder()
-                .category(TritonTypes.Category.Integration)
                 .type(TritonTypes.Type.Backend)
                 .area(TritonTypes.Area.Community)
                 .summary('HTTP Error')
@@ -1887,23 +1889,32 @@ private class TritonTest {
         Test.stopTest();
         
         List<pharos__Log__c> logs = [
-            SELECT Id, 
+            SELECT Id,
                    pharos__Category__c,
                    pharos__Type__c,
+                   pharos__Summary__c,
                    pharos__Stacktrace_Parse_Result__c
-            FROM pharos__Log__c 
+            FROM pharos__Log__c
             ORDER BY CreatedDate
         ];
-        
+
         System.assertEquals(3, logs.size(), 'Should have created event and integration error logs');
-        
-        // Verify integration logs have parsed request/response data
+
+        // Verify integration-payload logs default to Apex category and carry parsed request/response data
+        Integer payloadLogs = 0;
         for(pharos__Log__c log : logs) {
-            if(log.pharos__Category__c == TritonTypes.Category.Integration.name()) {
-                System.assertNotEquals(null, log.pharos__Stacktrace_Parse_Result__c, 
-                    'Integration log should have parsed request/response data');
+            if(log.pharos__Summary__c == 'Test Event') {
+                System.assertEquals(TritonTypes.Category.Event.name(), log.pharos__Category__c,
+                    'Event log should keep its explicit Event category');
+                continue;
             }
+            payloadLogs++;
+            System.assertEquals(TritonTypes.Category.Apex.name(), log.pharos__Category__c,
+                'Integration payload log should default to Apex category');
+            System.assertNotEquals(null, log.pharos__Stacktrace_Parse_Result__c,
+                'Integration payload log should carry parsed request/response data');
         }
+        System.assertEquals(2, payloadLogs, 'Both integration error logs should carry parsed request/response data');
     }
 
     @IsTest
@@ -2418,11 +2429,11 @@ private class TritonTest {
     @IsTest
     static void test_default_category_not_overridden() {
         pharos__Log__c log = Triton.makeBuilder()
-            .category(TritonTypes.Category.Integration)
+            .category(TritonTypes.Category.Event)
             .summary('test')
             .error()
             .build();
-        System.assertEquals(TritonTypes.Category.Integration.name(), log.pharos__Category__c, 'Explicit category should not be overridden');
+        System.assertEquals(TritonTypes.Category.Event.name(), log.pharos__Category__c, 'Explicit category should not be overridden');
     }
 
     @IsTest
@@ -2436,7 +2447,7 @@ private class TritonTest {
     @IsTest
     static void test_builder_clone() {
         TritonBuilder original = Triton.makeBuilder()
-            .category(TritonTypes.Category.Integration)
+            .category(TritonTypes.Category.Event)
             .type(TritonTypes.Type.Backend)
             .area(TritonTypes.Area.Community)
             .level(TritonTypes.Level.WARNING)
@@ -2446,7 +2457,7 @@ private class TritonTest {
         TritonBuilder cloned = original.cloneBuilder();
         pharos__Log__c clonedLog = cloned.build();
 
-        System.assertEquals(TritonTypes.Category.Integration.name(), clonedLog.pharos__Category__c,
+        System.assertEquals(TritonTypes.Category.Event.name(), clonedLog.pharos__Category__c,
             'Cloned builder should preserve category');
         System.assertEquals(TritonTypes.Type.Backend.name(), clonedLog.pharos__Type__c,
             'Cloned builder should preserve type');

--- a/force-app/main/default/classes/TritonTest.cls
+++ b/force-app/main/default/classes/TritonTest.cls
@@ -713,6 +713,44 @@ private class TritonTest {
         System.assertNotEquals(null, logs.get(0).pharos__Hash__c);
     }
 
+    /**
+     * Deprecated 'Integration' category is a sanctioned input (LOG-2927):
+     * mapped case-insensitively to the LWC context category,
+     * without the invalid-category note.
+     */
+    @IsTest
+    private static void test_save_component_log_integration_category_maps_to_lwc() {
+        TritonTestFactory.assertNoLogs();
+
+        Test.startTest();
+        List<TritonLwc.ComponentLog> componentLogs = new List<TritonLwc.ComponentLog>();
+        for (String categoryValue : new List<String>{'Integration', 'integration'}) {
+            TritonLwc.ComponentLog componentLog = new TritonLwc.ComponentLog();
+            componentLog.category = categoryValue;
+            componentLog.type = 'test type';
+            componentLog.area = TritonTypes.Area.LWC.name();
+            componentLog.level = TritonTypes.Level.ERROR.name();
+            componentLog.summary = 'integration category mapping: ' + categoryValue;
+            componentLog.details = 'test details';
+            TritonLwc.Component component = new TritonLwc.Component();
+            component.name = 'TestComponent';
+            component.function = 'testFunction';
+            componentLog.componentInfo = component;
+            componentLogs.add(componentLog);
+        }
+        TritonLwc.saveComponentLogs(componentLogs);
+        Test.stopTest();
+
+        List<pharos__Log__c> logs = [SELECT Id, pharos__Category__c, pharos__Details__c FROM pharos__Log__c];
+        System.assertEquals(2, logs.size(), 'Expected both component logs to be created');
+        for (pharos__Log__c log : logs) {
+            System.assertEquals(TritonTypes.Category.LWC.name(), log.pharos__Category__c,
+                'Deprecated Integration category should map to LWC, but was: ' + log.pharos__Category__c);
+            System.assert(log.pharos__Details__c == null || !log.pharos__Details__c.contains('Invalid Log Category'),
+                'Sanctioned Integration mapping must not append the invalid-category note');
+        }
+    }
+
     @IsTest
     private static void test_lwc_runtime_info() {
         TritonTestFactory.assertNoLogs();

--- a/force-app/main/default/classes/TritonTypes.cls
+++ b/force-app/main/default/classes/TritonTypes.cls
@@ -12,7 +12,7 @@
  * 
  * Key components:
  * - Area enum: Defines functional areas from a business perspective (e.g., OpportunityManagement, RestAPI)
- * - Category enum: Provides high-level classification of log entries (e.g., Apex, Flow, Integration)
+ * - Category enum: Provides high-level classification of log entries (e.g., Apex, Flow, LWC)
  * - Level enum: Defines log severity levels from ERROR to FINEST
  * - Type enum: Offers technical classification of log entries (e.g., Backend, Frontend, DMLResult)
  * 
@@ -50,8 +50,7 @@ public with sharing class TritonTypes {
         Aura,
         Warning,
         Event,
-        Debug,
-        Integration
+        Debug
     }
     /**
     * Log Levels.


### PR DESCRIPTION
Triton side of the Integration-category deprecation. Integration (callout/REST) logs become Apex-category logs carrying an integration payload via integrationPayload(req, res) — which is category-agnostic and unchanged.

- **Breaking change:** TritonTypes.Category.Integration enum member removed. Migration: delete the .category(Integration) call — the builder defaults to Apex — and keep .integrationPayload(). Customer Apex referencing the member fails to compile on update.
- **Sanctioned legacy-string mapping:** the string 'Integration' (any casing) passed to the Flow/LWC bridges is accepted and maps to the context's own category (Flow/LWC) with no error note; genuinely invalid strings keep the invalid-category note.
